### PR TITLE
Wrap get/set view for RenderWindow

### DIFF
--- a/dsfml/graphics.d
+++ b/dsfml/graphics.d
@@ -750,6 +750,20 @@ class RenderWindow:RenderTarget
 		}
 	}
 	
+	@property
+	{
+		void view(View newView)
+		{
+			sfRenderWindow_setView(sfPtr, newView.sfPtr);
+		}
+		View view()
+		{
+			return new View( sfView_copy(sfRenderWindow_getView(sfPtr)));
+			
+		}
+	} 
+
+	
 	void setMouseCursorVisible(bool visible)
 	{
 		visible ? sfRenderWindow_setMouseCursorVisible(sfPtr,sfTrue): sfRenderWindow_setMouseCursorVisible(sfPtr,sfFalse);


### PR DESCRIPTION
CSFML has functions for getting and setting a RenderWindow's viewport--I need these for my current project, at least, so this adds it as a r/w property, just like RenderTexture.
