### PR TITLE
GDC, doesn't like passing multiple parameters to isNumeric!()

### DIFF
--- a/dsfml/graphics.d
+++ b/dsfml/graphics.d
@@ -2075,7 +2075,7 @@ struct Rect(T)
 	}
 	
 	bool intersects(E,O)(Rect!(E) rectangle, out Rect!(O) intersection)
-	if(isNumeric!(E,O))
+	if(isNumeric!(E) && isNumeric!(O))
 	{
 		O interLeft = intersection.max(left, rectangle.left);
 		O interTop = intersection.max(top, rectangle.top);


### PR DESCRIPTION
I'm not sure if this a problem with DMD too, since I didn't test it there, but GDC complained about the if (isNumeric(E,O)) conditional on Rect.intersects. A simple change to a boolean && in the conditional made it a lot happier. 
