### PR TITLE
Explicitly store Cstrings so the compiler won't trash them

### DIFF
--- a/dsfml/graphics.d
+++ b/dsfml/graphics.d
@@ -1587,7 +1587,7 @@ class Text:Drawable
 	{
 		void String(string newString)
 		{
-			string_ = cast(const(void)*)toStringz(newString);
+			string_ = toStringz(newString);
 			sfText_setString(sfPtr, cast(immutable(char)*)string_);
 		}
 		
@@ -1601,7 +1601,7 @@ class Text:Drawable
 	{
 		void unicodeString(dstring newUnicodeString)
 		{
-			string_ = cast(const(void)*)toUint32Ptr(newUnicodeString);
+			string_ = toUint32Ptr(newUnicodeString);
 			sfText_setUnicodeString(sfPtr, cast(const(uint)*)string_);
 		}
 		


### PR DESCRIPTION
When compiler optimization is enabled on GDC, there aren't any in-D references saved to the Cstrings made by dsfml.graphics.Text, and the garbage collector will eat them. Phobos' reference file for std.string (http://dlang.org/phobos/std_string.html ) warns of exactly this. :) 

I've made a little workaround here to stop that from happening, by explicitly storing pointers to these converted strings in the class. 

Note, currently I'm doing the safer thing here and storing both a string and a dstring pointer. This is technically wasting memory if you use both properties on the same Text object, but I'm not sure how necessary that would be, and I'm personally happier without casts to and from void pointers. 
