### PR TITLE
Added default parameters to clear methods

### DIFF
--- a/dsfml/graphics.d
+++ b/dsfml/graphics.d
@@ -652,7 +652,7 @@ class RenderTexture:RenderTarget
 		sfRenderTexture_display(sfPtr);
 	}
 	
-	void clear(Color color)
+	void clear(Color color = Color.Black)
 	{
 		sfRenderTexture_clear(sfPtr, color);
 	}
@@ -826,7 +826,7 @@ class RenderWindow:RenderTarget
 		
 	}
 	
-	void clear(Color color)
+	void clear(Color color = Color.Black)
 	{
 		sfRenderWindow_clear(sfPtr, color);
 		


### PR DESCRIPTION
I made Color.Black to be a default parameter to RenderWindow.clear() and RenderTexture.clear(), because in the original SFML you can call this clear methods without specifying a color.
