### PR TITLE
Renamed all all.d files to package.d

### DIFF
--- a/src/dsfml/audio/package.d
+++ b/src/dsfml/audio/package.d
@@ -27,41 +27,23 @@ Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
 
 All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
 */
-module dsfml.graphics.all;
 
+module dsfml.audio;
+//pragma(lib,"dsfml-audio");
 public
 {
-	import dsfml.window.all;
-
-	import dsfml.graphics.blendmode;
-	import dsfml.graphics.circleshape;
-	import dsfml.graphics.color;
-	import dsfml.graphics.convexshape;
-	import dsfml.graphics.drawable;
-	import dsfml.graphics.font;
-	import dsfml.graphics.glyph;
-	import dsfml.graphics.image;
-	import dsfml.graphics.primitivetype;
-	import dsfml.graphics.rect;
-	import dsfml.graphics.rectangleshape;
-	import dsfml.graphics.renderstates;
-	import dsfml.graphics.rendertarget;
-	import dsfml.graphics.rendertexture;
-	import dsfml.graphics.renderwindow;
-	import dsfml.graphics.shader;
-	import dsfml.graphics.shape;
-	import dsfml.graphics.sprite;
-	import dsfml.graphics.text;
-	import dsfml.graphics.texture;
-	import dsfml.graphics.transform;
-	import dsfml.graphics.transformable;
-	import dsfml.graphics.vertex;
-	import dsfml.graphics.vertexarray;
-	import dsfml.graphics.view;
+	import dsfml.audio.listener;
+	import dsfml.audio.music;
+	import dsfml.audio.sound;
+	import dsfml.audio.soundbuffer;
+	import dsfml.audio.soundbufferrecorder;
+	import dsfml.audio.soundrecorder;
+	import dsfml.audio.soundsource;
+	import dsfml.audio.soundstream;
 }
 static this()
 {
-	sfErrGraphics_redirect();
+	sfErrAudio_redirect();
 }
 
-private extern(C) void sfErrGraphics_redirect();
+private extern(C) void sfErrAudio_redirect();

--- a/src/dsfml/graphics/package.d
+++ b/src/dsfml/graphics/package.d
@@ -27,28 +27,41 @@ Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
 
 All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
 */
-module dsfml.window.all;
-
-//pragma(lib,"dsfml-window");
+module dsfml.graphics;
 
 public
 {
-	import dsfml.system.all;
+	import dsfml.window;
 
-	import dsfml.window.context;
-	import dsfml.window.contextsettings;
-	import dsfml.window.event;
-	import dsfml.window.joystick;
-	import dsfml.window.keyboard;
-	import dsfml.window.mouse;
-	import dsfml.window.videomode;
-	import dsfml.window.window;
-	import dsfml.window.windowhandle;
+	import dsfml.graphics.blendmode;
+	import dsfml.graphics.circleshape;
+	import dsfml.graphics.color;
+	import dsfml.graphics.convexshape;
+	import dsfml.graphics.drawable;
+	import dsfml.graphics.font;
+	import dsfml.graphics.glyph;
+	import dsfml.graphics.image;
+	import dsfml.graphics.primitivetype;
+	import dsfml.graphics.rect;
+	import dsfml.graphics.rectangleshape;
+	import dsfml.graphics.renderstates;
+	import dsfml.graphics.rendertarget;
+	import dsfml.graphics.rendertexture;
+	import dsfml.graphics.renderwindow;
+	import dsfml.graphics.shader;
+	import dsfml.graphics.shape;
+	import dsfml.graphics.sprite;
+	import dsfml.graphics.text;
+	import dsfml.graphics.texture;
+	import dsfml.graphics.transform;
+	import dsfml.graphics.transformable;
+	import dsfml.graphics.vertex;
+	import dsfml.graphics.vertexarray;
+	import dsfml.graphics.view;
 }
 static this()
 {
-	sfErrWindow_redirect();
+	sfErrGraphics_redirect();
 }
 
-private extern(C) void sfErrWindow_redirect();
-
+private extern(C) void sfErrGraphics_redirect();

--- a/src/dsfml/network/package.d
+++ b/src/dsfml/network/package.d
@@ -27,19 +27,25 @@ Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
 
 All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
 */
-module dsfml.system.all;
-//pragma(lib,"dsfml-system");
+module dsfml.network;
+
+//pragma(lib,"dsfml-network");
+
 public
 {
-	import dsfml.system.clock;
-	import dsfml.system.err;
-	import dsfml.system.inputstream;
-	import dsfml.system.lock;
-	import dsfml.system.mutex;
-	import dsfml.system.sleep;
-	import dsfml.system.thread;
-	import dsfml.system.time;
-	import dsfml.system.vector2;
-	import dsfml.system.vector3;
+	import dsfml.network.ftp;
+	import dsfml.network.http;
+	import dsfml.network.ipaddress;
+	import dsfml.network.packet;
+	import dsfml.network.socket;
+	import dsfml.network.socketselector;
+	import dsfml.network.tcplistener;
+	import dsfml.network.tcpsocket;
+	import dsfml.network.udpsocket;
+}
+static this()
+{
+	sfErrNetwork_redirect();
 }
 
+private extern(C) void sfErrNetwork_redirect();

--- a/src/dsfml/system/package.d
+++ b/src/dsfml/system/package.d
@@ -27,23 +27,19 @@ Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
 
 All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
 */
-
-module dsfml.audio.all;
-//pragma(lib,"dsfml-audio");
+module dsfml.system;
+//pragma(lib,"dsfml-system");
 public
 {
-	import dsfml.audio.listener;
-	import dsfml.audio.music;
-	import dsfml.audio.sound;
-	import dsfml.audio.soundbuffer;
-	import dsfml.audio.soundbufferrecorder;
-	import dsfml.audio.soundrecorder;
-	import dsfml.audio.soundsource;
-	import dsfml.audio.soundstream;
-}
-static this()
-{
-	sfErrAudio_redirect();
+	import dsfml.system.clock;
+	import dsfml.system.err;
+	import dsfml.system.inputstream;
+	import dsfml.system.lock;
+	import dsfml.system.mutex;
+	import dsfml.system.sleep;
+	import dsfml.system.thread;
+	import dsfml.system.time;
+	import dsfml.system.vector2;
+	import dsfml.system.vector3;
 }
 
-private extern(C) void sfErrAudio_redirect();

--- a/src/dsfml/window/package.d
+++ b/src/dsfml/window/package.d
@@ -27,25 +27,28 @@ Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
 
 All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
 */
-module dsfml.network.all;
+module dsfml.window;
 
-//pragma(lib,"dsfml-network");
+//pragma(lib,"dsfml-window");
 
 public
 {
-	import dsfml.network.ftp;
-	import dsfml.network.http;
-	import dsfml.network.ipaddress;
-	import dsfml.network.packet;
-	import dsfml.network.socket;
-	import dsfml.network.socketselector;
-	import dsfml.network.tcplistener;
-	import dsfml.network.tcpsocket;
-	import dsfml.network.udpsocket;
+	import dsfml.system;
+
+	import dsfml.window.context;
+	import dsfml.window.contextsettings;
+	import dsfml.window.event;
+	import dsfml.window.joystick;
+	import dsfml.window.keyboard;
+	import dsfml.window.mouse;
+	import dsfml.window.videomode;
+	import dsfml.window.window;
+	import dsfml.window.windowhandle;
 }
 static this()
 {
-	sfErrNetwork_redirect();
+	sfErrWindow_redirect();
 }
 
-private extern(C) void sfErrNetwork_redirect();
+private extern(C) void sfErrWindow_redirect();
+


### PR DESCRIPTION
With the [new version of dmd](http://dlang.org/changelog.html?2.064#import_package) all all.d files can be renamed to package.d and modules can be imported more easily
