### PR TITLE
Pull in all subpackages in the main package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,13 @@
         "authors": ["Jeremy DeHaan"],
         "homepage": "https://github.com/Jebbs/DSFML",
         "license": "Zlib",
-        
+        "dependencies": {
+            "dsfml:audio": "~master",
+            "dsfml:graphics": "~master",
+            "dsfml:window": "~master",
+            "dsfml:network": "~master",
+            "dsfml:system": "~master"
+        },
         "subPackages":
         [
                 {


### PR DESCRIPTION
Hello,

It is an intuitive behavior for a project like DSFML to pull in all subpackages if you specify the main package as a dependency. Right now putting `dsfml` as a dependency in your DUB package does nothing of worth – one must use specific subpackages such as `dsfml:graphics`. My proposal is that the main package should pull in all subpackages, which is the usual behavior of similar DUB packages.

Of course, this still allows the usage of specific subpackages, so there aren't really any downsides or gotchas attached to this change.
