### PR TITLE
Update import from dsfml.window.all to dsfml.window

### DIFF
--- a/src/dsfml/window/event.d
+++ b/src/dsfml/window/event.d
@@ -140,7 +140,7 @@ unittest
 	import dsfml.graphics.font;
 	import dsfml.graphics.text;
 	import dsfml.graphics.renderwindow;
-	import dsfml.window.all;
+	import dsfml.window;
 	import std.conv;
 
 	string[int] keys;


### PR DESCRIPTION
When dsfml/window/all.d got renamed to dsfml/window/package.d, this line in the tests for event.d was not changed.
