### PR TITLE
Return value on property assigners

### DIFF
--- a/src/dsfml/graphics/circleshape.d
+++ b/src/dsfml/graphics/circleshape.d
@@ -63,9 +63,10 @@ class CircleShape:Shape
 
 	@property
 	{
-		void pointCount(uint newPointCount)
+		uint pointCount(uint newPointCount)
 		{
 			m_pointCount = newPointCount;
+			return newPointCount;
 		}
 		override uint pointCount()
 		{
@@ -75,10 +76,11 @@ class CircleShape:Shape
 
 	@property
 	{
-		void radius(float newRadius)
+		float radius(float newRadius)
 		{
 			m_radius = newRadius;
 			update();
+			return newRadius;
 		}
 		float radius()
 		{

--- a/src/dsfml/graphics/convexshape.d
+++ b/src/dsfml/graphics/convexshape.d
@@ -21,10 +21,11 @@ class ConvexShape:Shape
 
 	@property
 	{
-		void pointCount(uint newPointCount)
+		uint pointCount(uint newPointCount)
 		{
 			m_points.length = newPointCount;
 			update();
+			return newPointCount;
 		}
 		override uint pointCount()
 		{

--- a/src/dsfml/graphics/rectangleshape.d
+++ b/src/dsfml/graphics/rectangleshape.d
@@ -52,10 +52,11 @@ class RectangleShape:Shape
 
 	@property
 	{
-		void size(Vector2f theSize)
+		Vector2f size(Vector2f theSize)
 		{
 			m_size = theSize;
 			update();
+			return theSize;
 		}
 		Vector2f size()
 		{

--- a/src/dsfml/graphics/renderstates.d
+++ b/src/dsfml/graphics/renderstates.d
@@ -117,7 +117,7 @@ struct RenderStates
 
 	@property
 	{
-		void texture(const(Texture) theTexture)
+		const(Texture) texture(const(Texture) theTexture)
 		{
 			if(theTexture !is null)
 			{
@@ -128,7 +128,7 @@ struct RenderStates
 			{
 				m_texture = emptyTexture;
 			}
-			
+			return theTexture;
 		}
 		const(Texture) texture()
 		{
@@ -138,7 +138,7 @@ struct RenderStates
 	
 	@property
 	{
-		void shader(const(Shader) theShader)
+		const(Shader) shader(const(Shader) theShader)
 		{
 			if(theShader !is null)
 			{
@@ -148,6 +148,7 @@ struct RenderStates
 			{
 				m_shader = emptyShader;
 			}
+			return theShader;
 		}
 		const(Shader) shader()
 		{

--- a/src/dsfml/graphics/rendertarget.d
+++ b/src/dsfml/graphics/rendertarget.d
@@ -47,7 +47,7 @@ interface RenderTarget
 {
 	@property
 	{
-		void view(const(View) newView);
+		const(View) view(const(View) newView);
 		View view() const;
 	}  
 

--- a/src/dsfml/graphics/rendertexture.d
+++ b/src/dsfml/graphics/rendertexture.d
@@ -94,9 +94,10 @@ class RenderTexture:RenderTarget
 
 	@property
 	{
-		void smooth(bool newSmooth)
+		bool smooth(bool newSmooth)
 		{
 			sfRenderTexture_setSmooth(sfPtr, newSmooth);
+			return newSmooth;
 		}
 		bool smooth()
 		{
@@ -106,9 +107,10 @@ class RenderTexture:RenderTarget
 
 	@property
 	{
-		override void view(const(View) newView)
+		override const(View) view(const(View) newView)
 		{
 			sfRenderTexture_setView(sfPtr, newView.sfPtr);
+			return newView;
 		}
 		override View view() const
 		{

--- a/src/dsfml/graphics/renderwindow.d
+++ b/src/dsfml/graphics/renderwindow.d
@@ -139,9 +139,10 @@ class RenderWindow:Window,RenderTarget
 	
 	@property
 	{
-		override void position(Vector2i newPosition)
+		override Vector2i position(Vector2i newPosition)
 		{
 			sfRenderWindow_setPosition(sfPtr,newPosition.x, newPosition.y);
+			return newPosition;
 		}
 		
 		override Vector2i position()
@@ -154,9 +155,10 @@ class RenderWindow:Window,RenderTarget
 	
 	@property
 	{
-		override void size(Vector2u newSize)
+		override Vector2u size(Vector2u newSize)
 		{
 			sfRenderWindow_setSize(sfPtr, newSize.x, newSize.y);
+			return newSize;
 		}
 		override Vector2u size()
 		{

--- a/src/dsfml/graphics/shape.d
+++ b/src/dsfml/graphics/shape.d
@@ -69,10 +69,11 @@ class Shape:Drawable,Transformable
 	@property
 	{
 		//Set Texture Rect
-		void textureRect(IntRect rect)
+		IntRect textureRect(IntRect rect)
 		{
 			m_textureRect = rect;
 			updateTexCoords();
+			return rect;
 		}
 		//get texture Rect
 		IntRect textureRect() const
@@ -84,10 +85,11 @@ class Shape:Drawable,Transformable
 	@property
 	{
 		//set Fill color
-		void fillColor(Color color)
+		Color fillColor(Color color)
 		{
 			m_fillColor = color;
 			updateFillColors();
+			return color;
 		}
 		//get fill color
 		Color fillColor() const
@@ -99,10 +101,11 @@ class Shape:Drawable,Transformable
 	@property
 	{
 		//set outline color
-		void outlineColor(Color color)
+		Color outlineColor(Color color)
 		{
 			m_outlineColor = color;
 			updateOutlineColors();
+			return color;
 		}
 		//get outline color
 		Color outlineColor() const
@@ -114,10 +117,11 @@ class Shape:Drawable,Transformable
 	@property
 	{
 		//set ouline thickness
-		void outlineThickness(float thickness)
+		float outlineThickness(float thickness)
 		{
 			m_outlineThickness = thickness;
 			update();
+			return thickness;
 		}
 		//get outline thickness
 		float outlineThickness() const

--- a/src/dsfml/graphics/sprite.d
+++ b/src/dsfml/graphics/sprite.d
@@ -96,7 +96,7 @@ class Sprite:Drawable,Transformable
 	
 	@property
 	{
-		void textureRect(IntRect rect)
+		IntRect textureRect(IntRect rect)
 		{
 			if (rect != m_textureRect)
 			{
@@ -104,7 +104,7 @@ class Sprite:Drawable,Transformable
 				updatePositions();
 				updateTexCoords();
 			}
-			
+			return rect;
 		}
 		
 		IntRect textureRect()
@@ -115,13 +115,14 @@ class Sprite:Drawable,Transformable
 	
 	@property//color
 	{
-		void color(Color newColor)
+		Color color(Color newColor)
 		{
 			// Update the vertices' color
 			m_vertices[0].color = newColor;
 			m_vertices[1].color = newColor;
 			m_vertices[2].color = newColor;
 			m_vertices[3].color = newColor;
+			return newColor;
 		}
 		
 		Color color()

--- a/src/dsfml/graphics/transformable.d
+++ b/src/dsfml/graphics/transformable.d
@@ -40,25 +40,25 @@ interface Transformable
 	
 	@property
 	{
-		void position(Vector2f newPosition);
+		Vector2f position(Vector2f newPosition);
 		Vector2f position() const;
 	}
 	
 	@property
 	{
-		void rotation(float newRotation);
+		float rotation(float newRotation);
 		float rotation() const;
 	}
 	
 	@property
 	{
-		void scale(Vector2f newScale);
+		Vector2f scale(Vector2f newScale);
 		Vector2f scale() const;
 	}
 	
 	@property
 	{
-		void origin(Vector2f newOrigin);
+		Vector2f origin(Vector2f newOrigin);
 		Vector2f origin() const;
 	}
 	
@@ -72,11 +72,12 @@ mixin template NormalTransformable()
 {
 	@property
 	{
-		void position(Vector2f newPosition)
+		Vector2f position(Vector2f newPosition)
 		{
 			m_position = newPosition;
 			m_transformNeedUpdate = true;
 			m_inverseTransformNeedUpdate = true;
+			return newPosition;
 		}
 		
 		Vector2f position() const
@@ -87,7 +88,7 @@ mixin template NormalTransformable()
 	
 	@property
 	{
-		void rotation(float newRotation)
+		float rotation(float newRotation)
 		{
 			m_rotation = cast(float)fmod(newRotation, 360);
 			if(m_rotation < 0)
@@ -96,6 +97,7 @@ mixin template NormalTransformable()
 			}
 			m_transformNeedUpdate = true;
 			m_inverseTransformNeedUpdate = true;
+			return newRotation;
 		}
 		
 		float rotation() const
@@ -106,11 +108,12 @@ mixin template NormalTransformable()
 	
 	@property
 	{
-		void scale(Vector2f newScale)
+		Vector2f scale(Vector2f newScale)
 		{
 			m_scale = newScale;
 			m_transformNeedUpdate = true;
 			m_inverseTransformNeedUpdate = true;
+			return newScale;
 		}
 		
 		Vector2f scale() const
@@ -121,11 +124,12 @@ mixin template NormalTransformable()
 	
 	@property
 	{
-		void origin(Vector2f newOrigin)
+		Vector2f origin(Vector2f newOrigin)
 		{
 			m_origin = newOrigin;
 			m_transformNeedUpdate = true;
 			m_inverseTransformNeedUpdate = true;
+			return newOrigin;
 		}
 		
 		Vector2f origin() const

--- a/src/dsfml/graphics/view.d
+++ b/src/dsfml/graphics/view.d
@@ -60,9 +60,10 @@ class View
 
 	@property
 	{
-		void center(Vector2f newCenter)
+		Vector2f center(Vector2f newCenter)
 		{
 			sfView_setCenter(sfPtr, newCenter.x, newCenter.y);
+			return newCenter;
 		}
 		
 		Vector2f center()
@@ -76,9 +77,10 @@ class View
 	
 	@property
 	{
-		void size(Vector2f newSize)
+		Vector2f size(Vector2f newSize)
 		{
 			sfView_setSize(sfPtr, newSize.x, newSize.y);
+			return newSize;
 		}
 		
 		Vector2f size()
@@ -91,9 +93,10 @@ class View
 	
 	@property
 	{
-		void rotation(float newRotation)
+		float rotation(float newRotation)
 		{
 			sfView_setRotation(sfPtr, newRotation);
+			return newRotation;
 		}
 		float rotation()
 		{
@@ -104,9 +107,10 @@ class View
 	
 	@property
 	{
-		void viewport(FloatRect newTarget)
+		FloatRect viewport(FloatRect newTarget)
 		{
 			sfView_setViewport(sfPtr, newTarget.left, newTarget.top, newTarget.width, newTarget.height);
+			return newTarget;
 		}
 		FloatRect viewport()
 		{

--- a/src/dsfml/window/window.d
+++ b/src/dsfml/window/window.d
@@ -90,9 +90,10 @@ class Window
 
 	@property
 	{
-		void position(Vector2i newPosition)
+		Vector2i position(Vector2i newPosition)
 		{
 			sfWindow_setPosition(sfPtr,newPosition.x, newPosition.y);
+			return newPosition;
 		}
 		
 		Vector2i position()
@@ -105,9 +106,10 @@ class Window
 	
 	@property
 	{
-		void size(Vector2u newSize)
+		Vector2u size(Vector2u newSize)
 		{
 			sfWindow_setSize(sfPtr, newSize.x, newSize.y);
+			return newSize;
 		}
 		Vector2u size()
 		{


### PR DESCRIPTION
You should do that on all properties, this allows to do things like:

```
auto pos = sprite.position = Vector2f(1, 2);
```
