### PR TITLE
Imports on color.d

### DIFF
--- a/src/dsfml/graphics/color.d
+++ b/src/dsfml/graphics/color.d
@@ -29,6 +29,8 @@ All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license
 */
 module dsfml.graphics.color;
 
+import std.math, std.traits;
+
 struct Color
 {
 	ubyte r;


### PR DESCRIPTION
Use of min, max, and isNumeric were undefined, so I imported them.

It wasn't caught by a manual `dub build` because it's part of conditionally compiled code, but in my project when I actually use the `op +`, it failed. Simple bug, simple fix.
