### PR TITLE
Audio module DDoc

### DIFF
--- a/src/dsfml/audio/listener.d
+++ b/src/dsfml/audio/listener.d
@@ -49,8 +49,8 @@ import dsfml.system.vector3;
 final abstract class Listener
 {
 	/** 
-	 * The orientation of the listener in the scene.
-	 * The orientation defines the 3D axes of the listener (left, up, front) in the scene. The orientation vector doesn't have to be normalized. 
+	 * The orientation of the listener in the scene. The orientation defines the 3D axes of the listener (left, up, front) in the scene. The orientation vector doesn't have to be normalized. 
+	 * 
 	 * The default listener's orientation is (0, 0, -1).
 	 */
 	@property
@@ -71,8 +71,8 @@ final abstract class Listener
 	}
 
 	/** 
-	 * The global volume of all the sounds and musics.
-	 * The volume is a number between 0 and 100; it is combined with the individual volume of each sound / music. 
+	 * The global volume of all the sounds and musics. The volume is a number between 0 and 100; it is combined with the individual volume of each sound / music. 
+	 * 
 	 * The default value for the volume is 100 (maximum).
 	 */
 	@property

--- a/src/dsfml/audio/music.d
+++ b/src/dsfml/audio/music.d
@@ -74,6 +74,7 @@ class Music : SoundStream
 	 * Open a music from an audio file.
 	 * 
 	 * This function doesn't start playing the music (call play() to do so). 
+	 * 
 	 * Here is a complete list of all the supported audio formats: ogg, wav, flac, aiff, au, raw, paf, svx, nist, voc, ircam, w64, mat4, mat5 pvf, htk, sds, avr, sd2, caf, wve, mpc2k, rf64.
 	 * 
 	 * Params:
@@ -98,8 +99,10 @@ class Music : SoundStream
 	/**
 	 * Open a music from an audio file in memory.
 	 * 
-	 * This function doesn't start playing the music (call play() to do so). 
+	 * This function doesn't start playing the music (call play() to do so).
+	 *
 	 * Here is a complete list of all the supported audio formats: ogg, wav, flac, aiff, au, raw, paf, svx, nist, voc, ircam, w64, mat4, mat5 pvf, htk, sds, avr, sd2, caf, wve, mpc2k, rf64.
+	 * 
 	 * Since the music is not loaded completely but rather streamed continuously, the data must remain available as long as the music is playing (ie. you can't deallocate it right after calling this function).
 	 * 
 	 * Params:
@@ -123,7 +126,9 @@ class Music : SoundStream
 	 * Open a music from an audio file in memory.
 	 * 
 	 * This function doesn't start playing the music (call play() to do so). 
+	 * 
 	 * Here is a complete list of all the supported audio formats: ogg, wav, flac, aiff, au, raw, paf, svx, nist, voc, ircam, w64, mat4, mat5 pvf, htk, sds, avr, sd2, caf, wve, mpc2k, rf64.
+	 * 
 	 * Since the music is not loaded completely but rather streamed continuously, the stream must remain available as long as the music is playing (ie. you can't deallocate it right after calling this function).
 	 * 
 	 * Params:
@@ -205,8 +210,8 @@ class Music : SoundStream
 		/**
 		 * Define the audio stream parameters.
 		 * 
-		 * This function must be called by derived classes as soon as they know the audio settings of the stream to play. 
-		 * Any attempt to manipulate the stream (play(), ...) before calling this function will fail. 
+		 * This function must be called by derived classes as soon as they know the audio settings of the stream to play. Any attempt to manipulate the stream (play(), ...) before calling this function will fail. 
+		 * 
 		 * It can be called multiple times if the settings of the audio stream change, but only when the stream is stopped.
 		 * 
 		 * Params:

--- a/src/dsfml/audio/sound.d
+++ b/src/dsfml/audio/sound.d
@@ -44,13 +44,9 @@ import dsfml.system.time;
  + 		- Ability to modify output parameters in real-time (pitch, volume, ...)
  + 		- 3D spatial features (position, attenuation, ...).
  + 
- + Sound is perfect for playing short sounds that can fit in memory and require no latency, like foot steps or gun shots.
- + For longer sounds, like background musics or long speeches, rather see Music (which is based on streaming).
+ + Sound is perfect for playing short sounds that can fit in memory and require no latency, like foot steps or gun shots. For longer sounds, like background musics or long speeches, rather see Music (which is based on streaming).
  + 
- + In order to work, a sound must be given a buffer of audio data to play.
- + Audio data (samples) is stored in SoundBuffer, and attached to a sound with the setBuffer() function.
- + The buffer object attached to a sound must remain alive as long as the sound uses it.
- + Note that multiple sounds can use the same sound buffer at the same time.
+ + In order to work, a sound must be given a buffer of audio data to play. Audio data (samples) is stored in SoundBuffer, and attached to a sound with the setBuffer() function. The buffer object attached to a sound must remain alive as long as the sound uses it. Note that multiple sounds can use the same sound buffer at the same time.
  + 
  + See_Also: http://www.sfml-dev.org/documentation/2.0/classsf_1_1Sound.php#details
  + Authors: Laurent Gomila, Jeremy DeHaan
@@ -91,6 +87,7 @@ class Sound : SoundSource
 	 * Whether or not the sound should loop after reaching the end.
 	 * 
 	 * If set, the sound will restart from beginning after reaching the end and so on, until it is stopped or setLoop(false) is called.
+	 * 
 	 * The default looping state for sound is false.
 	 */
 	@property
@@ -138,9 +135,7 @@ class Sound : SoundSource
 	// (note: if this is changed to a property, change the 
 	// documentation at the top of the file accordingly)
 	/*
-	 * Set the source buffer containing the audio data to play.
-	 * It is important to note that the sound buffer is not copied, 
-	 * thus the SoundBuffer instance must remain alive as long as it is attached to the sound.
+	 * Set the source buffer containing the audio data to play. It is important to note that the sound buffer is not copied, thus the SoundBuffer instance must remain alive as long as it is attached to the sound.
 	 * 
 	 * Params:
 	 * 		buffer =	Sound buffer to attach to the sound
@@ -174,8 +169,8 @@ class Sound : SoundSource
 	/**
 	 * Start or resume playing the sound.
 	 * 
-	 * This function starts the stream if it was stopped, resumes it if it was paused,
-	 * and restarts it from beginning if it was it already playing.
+	 * This function starts the stream if it was stopped, resumes it if it was paused, and restarts it from beginning if it was it already playing.
+	 * 
 	 * This function uses its own thread so that it doesn't block the rest of the program while the sound is played.
 	 */
 	void play()
@@ -185,8 +180,7 @@ class Sound : SoundSource
 
 	/// Reset the internal buffer of the sound.
 	/// 
-	/// This function is for internal use only, you don't have to use it. It is called by the SoundBuffer that this sound uses, 
-	/// when it is destroyed in order to prevent the sound from using a dead buffer.
+	/// This function is for internal use only, you don't have to use it. It is called by the SoundBuffer that this sound uses, when it is destroyed in order to prevent the sound from using a dead buffer.
 	void resetBuffer()
 	{
 		//stop the current sound;
@@ -199,8 +193,7 @@ class Sound : SoundSource
 
 	/// Stop playing the sound.
 	/// 
-	/// This function stops the sound if it was playing or paused, and does nothing if it was already stopped.
-	/// It also resets the playing position (unlike pause()).
+	/// This function stops the sound if it was playing or paused, and does nothing if it was already stopped. It also resets the playing position (unlike pause()).
 	void stop()
 	{
 		sfSoundStream_alSourceStop(m_source);

--- a/src/dsfml/audio/soundbuffer.d
+++ b/src/dsfml/audio/soundbuffer.d
@@ -51,20 +51,15 @@ import std.conv;
 /++
  + Storage for audio samples defining a sound.
  + 
- + A sample is a 16 bits signed integer that defines the amplitude of the sound at a given time. 
- + The sound is then restituted by playing these samples at a high rate (for example, 44100 samples per second is the standard rate used for playing CDs). 
- + In short, audio samples are like texture pixels, and a SoundBuffer is similar to a Texture.
+ + A sample is a 16 bits signed integer that defines the amplitude of the sound at a given time. The sound is then restituted by playing these samples at a high rate (for example, 44100 samples per second is the standard rate used for playing CDs). In short, audio samples are like texture pixels, and a SoundBuffer is similar to a Texture.
  + 
- + A sound buffer can be loaded from a file (see loadFromFile() for the complete list of supported formats), from memory, from a custom stream (see InputStream) or directly from an array of samples. 
- + It can also be saved back to a file.
+ + A sound buffer can be loaded from a file (see loadFromFile() for the complete list of supported formats), from memory, from a custom stream (see InputStream) or directly from an array of samples. It can also be saved back to a file.
  + 
- + Sound buffers alone are not very useful: they hold the audio data but cannot be played. 
- + To do so, you need to use the sf::Sound class, which provides functions to play/pause/stop the sound as well as changing the way it is outputted (volume, pitch, 3D position, ...). 
- + This separation allows more flexibility and better performances: indeed a sf::SoundBuffer is a heavy resource, and any operation on it is slow (often too slow for real-time applications). 
- + On the other side, a sf::Sound is a lightweight object, which can use the audio data of a sound buffer and change the way it is played without actually modifying that data. Note that it is also possible to bind several Sound instances to the same SoundBuffer.
+ + Sound buffers alone are not very useful: they hold the audio data but cannot be played. To do so, you need to use the sf::Sound class, which provides functions to play/pause/stop the sound as well as changing the way it is outputted (volume, pitch, 3D position, ...). 
  + 
- + It is important to note that the Sound instance doesn't copy the buffer that it uses, it only keeps a reference to it.
- + Thus, a SoundBuffer must not be destructed while it is used by a Sound (i.e. never write a function that uses a local SoundBuffer instance for loading a sound).
+ + This separation allows more flexibility and better performances: indeed a sf::SoundBuffer is a heavy resource, and any operation on it is slow (often too slow for real-time applications). On the other side, a sf::Sound is a lightweight object, which can use the audio data of a sound buffer and change the way it is played without actually modifying that data. Note that it is also possible to bind several Sound instances to the same SoundBuffer.
+ + 
+ + It is important to note that the Sound instance doesn't copy the buffer that it uses, it only keeps a reference to it. Thus, a SoundBuffer must not be destructed while it is used by a Sound (i.e. never write a function that uses a local SoundBuffer instance for loading a sound).
  + 
  + See_Also: http://www.sfml-dev.org/documentation/2.0/classsf_1_1SoundBuffer.php#details
  + Authors: Laurent Gomila, Jeremy DeHaan
@@ -119,8 +114,7 @@ class SoundBuffer
 	/** 
 	 * Get the array of audio samples stored in the buffer.
 	 * 
-	 *  The format of the returned samples is 16 bits signed integer (sf::Int16). 
-	 *  The total number of samples in this array is given by the getSampleCount() function.
+	 *  The format of the returned samples is 16 bits signed integer (sf::Int16). The total number of samples in this array is given by the getSampleCount() function.
 	 * 
 	 *  Returns: Read-only pointer to the array of sound samples
 	 */
@@ -132,8 +126,7 @@ class SoundBuffer
 	/**
 	 * Get the sample rate of the sound.
 	 * 
-	 * The sample rate is the number of samples played per second. 
-	 * The higher, the better the quality (for example, 44100 samples/s is CD quality).
+	 * The sample rate is the number of samples played per second. The higher, the better the quality (for example, 44100 samples/s is CD quality).
 	 * 
 	 * Returns: Sample rate (number of samples per second)
 	 */

--- a/src/dsfml/audio/soundbufferrecorder.d
+++ b/src/dsfml/audio/soundbufferrecorder.d
@@ -67,8 +67,7 @@ class SoundBufferRecorder:SoundRecorder
 	/**
 	 * Get the sound buffer containing the captured audio data.
 	 * 
-	 * The sound buffer is valid only after the capture has ended. 
-	 * This function provides a read-only access to the internal sound buffer, but it can be copied if you need to make any modification to it.
+	 * The sound buffer is valid only after the capture has ended. This function provides a read-only access to the internal sound buffer, but it can be copied if you need to make any modification to it.
 	 * 
 	 * Returns: Read-only access to the sound buffer
 	 */

--- a/src/dsfml/audio/soundrecorder.d
+++ b/src/dsfml/audio/soundrecorder.d
@@ -39,22 +39,20 @@ import std.conv;
  + 
  + SoundBuffer provides a simple interface to access the audio recording capabilities of the computer (the microphone).
  + 
- + As an abstract base class, it only cares about capturing sound samples, the task of making something useful with them is left to the derived class. 
- + Note that SFML provides a built-in specialization for saving the captured data to a sound buffer (see SoundBufferRecorder).
+ + As an abstract base class, it only cares about capturing sound samples, the task of making something useful with them is left to the derived class. Note that SFML provides a built-in specialization for saving the captured data to a sound buffer (see SoundBufferRecorder).
  + 
  + A derived class has only one virtual function to override:
  + 
  + onProcessSamples provides the new chunks of audio samples while the capture happens
+ + 
  + Moreover, two additionnal virtual functions can be overriden as well if necessary:
  + 
  + onStart is called before the capture happens, to perform custom initializations
  + onStop is called after the capture ends, to perform custom cleanup
- + The audio capture feature may not be supported or activated on every platform, thus it is recommended to check its availability with the isAvailable() function. 
- + If it returns false, then any attempt to use an audio recorder will fail.
  + 
- + It is important to note that the audio capture happens in a separate thread, so that it doesn't block the rest of the program. 
- + In particular, the onProcessSamples and onStop virtual functions (but not onStart) will be called from this separate thread. 
- + It is important to keep this in mind, because you may have to take care of synchronization issues if you share data between threads.
+ + The audio capture feature may not be supported or activated on every platform, thus it is recommended to check its availability with the isAvailable() function. If it returns false, then any attempt to use an audio recorder will fail.
+ + 
+ + It is important to note that the audio capture happens in a separate thread, so that it doesn't block the rest of the program. In particular, the onProcessSamples and onStop virtual functions (but not onStart) will be called from this separate thread. It is important to keep this in mind, because you may have to take care of synchronization issues if you share data between threads.
  + 
  + See_Also: http://www.sfml-dev.org/documentation/2.0/classsf_1_1SoundRecorder.php#details
  + Authors: Laurent Gomila, Jeremy DeHaan
@@ -88,10 +86,7 @@ class SoundRecorder
 
 	/**
 	 * Start the capture.
-	 * The sampleRate parameter defines the number of audio samples captured per second. 
-	 * The higher, the better the quality (for example, 44100 samples/sec is CD quality).
-	 * This function uses its own thread so that it doesn't block the rest of the program while the capture runs.
-	 * Please note that only one capture can happen at the same time.
+	 * The sampleRate parameter defines the number of audio samples captured per second. The higher, the better the quality (for example, 44100 samples/sec is CD quality). This function uses its own thread so that it doesn't block the rest of the program while the capture runs. Please note that only one capture can happen at the same time.
 	 * 
 	 * Params:
 	 * 		sampleRate =	Desired capture rate, in number of samples per second
@@ -130,8 +125,7 @@ class SoundRecorder
 	/**
 	 * Get the sample rate in samples per second.
 	 * 
-	 * The sample rate defines the number of audio samples captured per second.
-	 * The higher, the better the quality (for example, 44100 samples/sec is CD quality).
+	 * The sample rate defines the number of audio samples captured per second. The higher, the better the quality (for example, 44100 samples/sec is CD quality).
 	 */
 	@property
 	{
@@ -144,8 +138,7 @@ class SoundRecorder
 	/**
 	 * Check if the system supports audio capture.
 	 * 
-	 * This function should always be called before using the audio capture features. 
-	 * If it returns false, then any attempt to use SoundRecorder or one of its derived classes will fail.
+	 * This function should always be called before using the audio capture features. If it returns false, then any attempt to use SoundRecorder or one of its derived classes will fail.
 	 * 
 	 * Returns: True if audio capture is supported, false otherwise
 	 */
@@ -159,8 +152,7 @@ class SoundRecorder
 		/**
 		 * Start capturing audio data.
 		 * 
-		 * This virtual function may be overriden by a derived class if something has to be done every time a new capture starts. 
-		 * If not, this function can be ignored; the default implementation does nothing.
+		 * This virtual function may be overriden by a derived class if something has to be done every time a new capture starts. If not, this function can be ignored; the default implementation does nothing.
 		 * 
 		 * Returns: True to the start the capture, or false to abort it.
 		 */
@@ -169,8 +161,7 @@ class SoundRecorder
 		/**
 		 * Process a new chunk of recorded samples.
 		 * 
-		 * This virtual function is called every time a new chunk of recorded data is available. 
-		 * The derived class can then do whatever it wants with it (storing it, playing it, sending it over the network, etc.).
+		 * This virtual function is called every time a new chunk of recorded data is available. The derived class can then do whatever it wants with it (storing it, playing it, sending it over the network, etc.).
 		 * 
 		 * Params:
 		 * 		samples =	Array of the new chunk of recorded samples
@@ -182,8 +173,7 @@ class SoundRecorder
 		/**
 		 * Stop capturing audio data.
 		 * 
-		 * This virtual function may be overriden by a derived class if something has to be done every time the capture ends. 
-		 * If not, this function can be ignored; the default implementation does nothing.
+		 * This virtual function may be overriden by a derived class if something has to be done every time the capture ends. If not, this function can be ignored; the default implementation does nothing.
 		 */
 		abstract void onStop();
 

--- a/src/dsfml/audio/soundsource.d
+++ b/src/dsfml/audio/soundsource.d
@@ -39,8 +39,7 @@ import dsfml.system.err;
  + 
  + SoundSource is not meant to be used directly, it only serves as a common base for all audio objects that can live in the audio environment.
  + 
- + It defines several properties for the sound: pitch, volume, position, attenuation, etc. 
- + All of them can be changed at any time with no impact on performances.
+ + It defines several properties for the sound: pitch, volume, position, attenuation, etc. All of them can be changed at any time with no impact on performances.
  + 
  + See_Also: http://sfml-dev.org/documentation/2.0/classsf_1_1SoundSource.php#details
  + Authors: Laurent Gomila, Jeremy DeHaan
@@ -85,9 +84,7 @@ class SoundSource
 	/**
 	 * The pitch of the sound.
 	 * 
-	 * The pitch represents the perceived fundamental frequency of a sound; thus you can make a sound more acute or grave by changing its pitch. 
-	 * A side effect of changing the pitch is to modify the playing speed of the sound as well. 
-	 * The default value for the pitch is 1.
+	 * The pitch represents the perceived fundamental frequency of a sound; thus you can make a sound more acute or grave by changing its pitch. A side effect of changing the pitch is to modify the playing speed of the sound as well. The default value for the pitch is 1.
 	 */
 	@property
 	{
@@ -105,8 +102,7 @@ class SoundSource
 	/**
 	 * The volume of the sound.
 	 * 
-	 * The volume is a vlue between 0 (mute) and 100 (full volume).
-	 * The default value for the volume is 100.
+	 * The volume is a vlue between 0 (mute) and 100 (full volume). The default value for the volume is 100.
 	 */
 	@property
 	{
@@ -124,8 +120,7 @@ class SoundSource
 	/**
 	 * The 3D position of the sound in the audio scene.
 	 * 
-	 * Only sounds with one channel (mono sounds) can be spatialized. 
-	 * The default position of a sound is (0, 0, 0).
+	 * Only sounds with one channel (mono sounds) can be spatialized. The default position of a sound is (0, 0, 0).
 	 */
 	@property
 	{
@@ -148,9 +143,7 @@ class SoundSource
 	/**
 	 * Make the sound's position relative to the listener (true) or absolute (false).
 	 * 
-	 * Making a sound relative to the listener will ensure that it will always be played the same way regardless the position of the listener. 
-	 * This can be useful for non-spatialized sounds, sounds that are produced by the listener, or sounds attached to it. 
-	 * The default value is false (position is absolute).
+	 * Making a sound relative to the listener will ensure that it will always be played the same way regardless the position of the listener.  This can be useful for non-spatialized sounds, sounds that are produced by the listener, or sounds attached to it. The default value is false (position is absolute).
 	 */
 	@property
 	{
@@ -168,10 +161,7 @@ class SoundSource
 	/**
 	 * The minimum distance of the sound.
 	 * 
-	 * The "minimum distance" of a sound is the maximum distance at which it is heard at its maximum volume. 
-	 * Further than the minimum distance, it will start to fade out according to its attenuation factor. 
-	 * A value of 0 ("inside the head of the listener") is an invalid value and is forbidden. 
-	 * The default value of the minimum distance is 1.
+	 * The "minimum distance" of a sound is the maximum distance at which it is heard at its maximum volume. Further than the minimum distance, it will start to fade out according to its attenuation factor. A value of 0 ("inside the head of the listener") is an invalid value and is forbidden. The default value of the minimum distance is 1.
 	 */
 	@property
 	{
@@ -189,10 +179,9 @@ class SoundSource
 	/**
 	 * The attenuation factor of the sound.
 	 * 
-	 * The attenuation is a multiplicative factor which makes the sound more or less loud according to its distance from the listener. 
-	 * An attenuation of 0 will produce a non-attenuated sound, i.e. its volume will always be the same whether it is heard from near or from far. 
-	 * On the other hand, an attenuation value such as 100 will make the sound fade out very quickly as it gets further from the listener. 
-	 * The default value of the attenuation is 1.
+	 * The attenuation is a multiplicative factor which makes the sound more or less loud according to its distance from the listener. An attenuation of 0 will produce a non-attenuated sound, i.e. its volume will always be the same whether it is heard from near or from far. 
+	 * 
+	 * On the other hand, an attenuation value such as 100 will make the sound fade out very quickly as it gets further from the listener. The default value of the attenuation is 1.
 	 */
 	@property
 	{

--- a/src/dsfml/audio/soundstream.d
+++ b/src/dsfml/audio/soundstream.d
@@ -43,21 +43,17 @@ import dsfml.system.time;
  + 
  + Unlike audio buffers (see SoundBuffer), audio streams are never completely loaded in memory.
  + 
- + Instead, the audio data is acquired continuously while the stream is playing. 
- + This behaviour allows to play a sound with no loading delay, and keeps the memory consumption very low.
+ + Instead, the audio data is acquired continuously while the stream is playing. This behaviour allows to play a sound with no loading delay, and keeps the memory consumption very low.
  + 
  + Sound sources that need to be streamed are usually big files (compressed audio musics that would eat hundreds of MB in memory) or files that would take a lot of time to be received (sounds played over the network).
  + 
- + SoundStream is a base class that doesn't care about the stream source, which is left to the derived class. SFML provides a built-in specialization for big files (see Music). 
- + No network stream source is provided, but you can write your own by combining this class with the network module.
+ + SoundStream is a base class that doesn't care about the stream source, which is left to the derived class. SFML provides a built-in specialization for big files (see Music). No network stream source is provided, but you can write your own by combining this class with the network module.
  + 
  + A derived class has to override two virtual functions:
  + 		- onGetData fills a new chunk of audio data to be played.
  + 		- onSeek changes the current playing position in the source
  + 
- + It is important to note that each SoundStream is played in its own separate thread, so that the streaming loop doesn't block the rest of the program. 
- + In particular, the OnGetData and OnSeek virtual functions may sometimes be called from this separate thread. 
- + It is important to keep this in mind, because you may have to take care of synchronization issues if you share data between threads.
+ + It is important to note that each SoundStream is played in its own separate thread, so that the streaming loop doesn't block the rest of the program. In particular, the OnGetData and OnSeek virtual functions may sometimes be called from this separate thread. It is important to keep this in mind, because you may have to take care of synchronization issues if you share data between threads.
  + 
  + See_Also: http://sfml-dev.org/documentation/2.0/classsf_1_1SoundStream.php#details
  + Authors: Laurent Gomila, Jeremy DeHaan
@@ -182,8 +178,7 @@ class SoundStream:SoundSource
 	/**
 	 * Whether or not the stream should loop after reaching the end.
 	 * 
-	 * If set, the stream will restart from the beginning after reaching the end and so on,
-	 * until it is stopped or looping is set to false.
+	 * If set, the stream will restart from the beginning after reaching the end and so on, until it is stopped or looping is set to false.
 	 * 
 	 * Default looping state for streams is false.
 	 */
@@ -210,8 +205,7 @@ class SoundStream:SoundSource
 
 	/// Play or resume playing the audio stream.
 	/// 
-	/// This function starts the stream if it was stopped, resumes it if it was paused, and restarts it from beginning if it was it already playing. 
-	/// This function uses its own thread so that it doesn't block the rest of the program while the stream is played.
+	/// This function starts the stream if it was stopped, resumes it if it was paused, and restarts it from beginning if it was it already playing. This function uses its own thread so that it doesn't block the rest of the program while the stream is played.
 	void play()
 	{
 		import dsfml.system.err;
@@ -241,8 +235,7 @@ class SoundStream:SoundSource
 
 	/// Stop playing the audio stream
 	/// 
-	/// This function stops the stream if it was playing or paused, and does nothing if it was already stopped. 
-	/// It also resets the playing position (unlike pause()).
+	/// This function stops the stream if it was playing or paused, and does nothing if it was already stopped. It also resets the playing position (unlike pause()).
 	void stop()
 	{
 		m_isStreaming = false;
@@ -258,9 +251,7 @@ protected:
 	/**
 	 * Define the audio stream parameters.
 	 * 
-	 * This function must be called by derived classes as soon as they know the audio settings of the stream to play. 
-	 * Any attempt to manipulate the stream (play(), ...) before calling this function will fail. 
-	 * It can be called multiple times if the settings of the audio stream change, but only when the stream is stopped.
+	 * This function must be called by derived classes as soon as they know the audio settings of the stream to play. Any attempt to manipulate the stream (play(), ...) before calling this function will fail. It can be called multiple times if the settings of the audio stream change, but only when the stream is stopped.
 	 * 
 	 * Params:
 	 * 		theChannelCount =	Number of channels of the stream
@@ -289,9 +280,7 @@ protected:
 	/**
 	 * Request a new chunk of audio.
 	 * 
-	 * This function must be overridden by derived classes to provide the audio samples to play.
-	 * It is called continuously by the streaming loop, in a separate thread.
-	 * The source can choose to stop the streaming loop at any time, by returning false to the caller.
+	 * This function must be overridden by derived classes to provide the audio samples to play. It is called continuously by the streaming loop, in a separate thread. The source can choose to stop the streaming loop at any time, by returning false to the caller.
 	 * 
 	 * Params:
 	 * 		data =	Chunk of data to fill


### PR DESCRIPTION
Added documentation to the audio module. It was taken from the official SFML documentation and placed in comments in a way that can be used by DDoc and other parsers like Mono-D for code suggestions. I'll be doing the others, eventually, but it is very tedious and I want to make sure that nobody's toes will get stepped on when I put them in.

Regarding #33 
