### PR TITLE
opIndexAssign for shader parameters

### DIFF
--- a/src/dsfml/graphics/shader.d
+++ b/src/dsfml/graphics/shader.d
@@ -178,6 +178,55 @@ class Shader
 		err.write(text(sfErrGraphics_getOutput()));
 		return (sfPtr == null)?false:true;
 	}
+
+	void opIndexAssign(float x, string name)
+	{
+		sfShader_setFloatParameter(sfPtr, toStringz(name), x);
+	}
+
+	void opIndexAssign(float[] val, string name)
+	{
+		if(val.length == 1)
+			sfShader_setFloatParameter(sfPtr, toStringz(key), val[0]);
+		else if(val.length == 2)
+			sfShader_setFloat2Parameter(sfPtr, toStringz(key), val[0], val[1]);
+		else if(val.length == 3)
+			sfShader_setFloat3Parameter(sfPtr, toStringz(key), val[0], val[1], val[2]);
+		else if(val.length >= 4)
+			sfShader_setFloat4Parameter(sfPtr, toStringz(key), val[0], val[1], val[2], val[3]);
+	}
+
+	void opIndexAssign(Vector2f vector, string name)
+	{
+		sfShader_setFloat2Parameter(sfPtr, toStringz(name), vector.x, vector.y);
+	}
+
+	void opIndexAssign(Vector3f vector, string name)
+	{
+		sfShader_setFloat3Parameter(sfPtr, toStringz(name), vector.x, vector.y, vector.z);
+	}
+	
+	void opIndexAssign(Color color, string name)
+	{
+		sfShader_setColorParameter(sfPtr, toStringz(name), color.r, color.g, color.b, color.a);
+	}
+	
+	void opIndexAssign(Transform transform, string name)
+	{
+		sfShader_setTransformParameter(sfPtr, toStringz(name), transform.m_matrix.ptr);
+	}
+	
+	void opIndexAssign(Texture texture, string name)
+	{
+		import std.conv;
+		sfShader_setTextureParameter(sfPtr, toStringz(name), texture.sfPtr);
+		err.write(text(sfErrGraphics_getOutput()));
+	}
+	
+	void opIndexAssign(CurrentTextureType, string name)
+	{
+		sfShader_setCurrentTextureParameter(sfPtr, toStringz(name));
+	}
 	
 	void setParameter(string name, float x)
 	{


### PR DESCRIPTION
I'm not entirely sure if this is a good idea or not - it seems convenient, but I'm more concerned that it goes against the design model you have for DSFML (that is, more focus on staying true-to-form). Regardless, I thought I'd bring it up.

With these index assign overloads in shader, something like this could happen (reminiscent of how XNA decided to do things):

```
myShader["bumpMap"] = someTexture;
myShader["values"] = [15, 24.6, 200];
myShader["backColor"] = Color.Red;
```

Note that these are only assign overloads. You can't read values this way, only write, which seems appropriate.
