### PR TITLE
Fixed null check in findCharacter

### DIFF
--- a/src/dsfml/graphics/text.d
+++ b/src/dsfml/graphics/text.d
@@ -309,7 +309,7 @@ class Text : Drawable, Transformable
 	Vector2f findCharacterPos(size_t index)
 	{
 		// Make sure that we have a valid font
-		if(m_font !is null)
+		if(m_font is null)
 		{
 			return Vector2f(0,0);
 		}


### PR DESCRIPTION
The comments and logic both indicate that when a font is null, that find character should return 0 values rather than attempting to find a character.

This pull request reverses the current incorrect "not null" check and replaced it with a null check.