### PR TITLE
Remove static constructors from RenderStates and IpAddress

### DIFF
--- a/src/dsfml/graphics/renderstates.d
+++ b/src/dsfml/graphics/renderstates.d
@@ -27,23 +27,23 @@ import std.typecons:Rebindable;
 
 /++
  + Define the states used for drawing to a RenderTarget.
- + 
+ +
  + There are four global states that can be applied to the drawn objects:
  + - the blend mode: how pixels of the object are blended with the background
  + - the transform: how the object is positioned/rotated/scaled
  + - the texture: what image is mapped to the object
  + - the shader: what custom effect is applied to the object
- + 
+ +
  + High-level objects such as sprites or text force some of these states when they are drawn. For example, a sprite will set its own texture, so that you don't have to care about it when drawing the sprite.
- + 
+ +
  + The transform is a special case: sprites, texts and shapes (and it's a good idea to do it with your own drawable classes too) combine their transform with the one that is passed in the RenderStates structure. So that you can use a "global" transform on top of each object's transform.
- + 
+ +
  + Most objects, especially high-level drawables, can be drawn directly without defining render states explicitely – the default set of states is ok in most cases.
- + 
+ +
  + If you want to use a single specific render state, for example a shader, you can pass it directly to the Draw function: RenderStates has an implicit one-argument constructor for each state.
- + 
+ +
  + When you're inside the Draw function of a drawable object (inherited from sf::Drawable), you can either pass the render states unmodified, or change some of them. For example, a transformable object will combine the current transform with its own transform. A sprite will set its texture. Etc.
- + 
+ +
  + Authors: Laurent Gomila, Jeremy DeHaan
  + See_Also: http://www.sfml-dev.org/documentation/2.0/classsf_1_1RenderStates.php#details
  +/
@@ -62,8 +62,8 @@ struct RenderStates
 		blendMode = theBlendMode;
 		transform = Transform();
 
-		m_texture = emptyTexture;
-		m_shader = emptyShader;
+		m_texture = null;
+		m_shader = null;
 
 	}
 
@@ -73,61 +73,31 @@ struct RenderStates
 
 		blendMode = BlendMode.Alpha;
 
-		m_texture = emptyTexture;
-		m_shader = emptyShader;
+		m_texture = null;
+		m_shader = null;
 	}
 
 	this(const(Texture) theTexture)
 	{
-		if(theTexture !is null)
-		{
-			
-			m_texture = theTexture;
-		}
-		else
-		{
-			m_texture = emptyTexture;
-		}
+		m_texture = theTexture;
 
 		blendMode = BlendMode.Alpha;
 
 		transform = Transform();
-		m_shader = emptyShader;
+		m_shader = null;
 	}
 
 	this(const(Shader) theShader)
 	{
-		if(theShader !is null)
-		{
-			m_shader = theShader;
-		}
-		else
-		{
-			m_shader = emptyShader;
-		}
+		m_shader = theShader;
 	}
 
 	this(BlendMode theBlendMode, Transform theTransform, const(Texture) theTexture, const(Shader) theShader)
 	{
 		blendMode = theBlendMode;
 		transform = theTransform;
-		if(theTexture !is null)
-		{
-			
-			m_texture = theTexture;
-		}
-		else
-		{
-			m_texture = emptyTexture;
-		}
-		if(theShader !is null)
-		{
-			m_shader = theShader;
-		}
-		else
-		{
-			m_shader = emptyShader;
-		}
+		m_texture = theTexture;
+		m_shader = theShader;
 	}
 
 	/// The shader to apply while rendering.
@@ -135,14 +105,7 @@ struct RenderStates
 	{
 		const(Shader) shader(const(Shader) theShader)
 		{
-			if(theShader !is null)
-			{
-				m_shader = theShader;
-			}
-			else
-			{
-				m_shader = emptyShader;
-			}
+			m_shader = theShader;
 			return theShader;
 		}
 		const(Shader) shader()
@@ -156,43 +119,12 @@ struct RenderStates
 	{
 		const(Texture) texture(const(Texture) theTexture)
 		{
-			if(theTexture !is null)
-			{
-				
-				m_texture = theTexture;
-			}
-			else
-			{
-				m_texture = emptyTexture;
-			}
+			m_texture = theTexture;
 			return theTexture;
 		}
 		const(Texture) texture()
 		{
 			return m_texture;
 		}
-	}
-
-	/// A default, empty render state.
-	@property
-	static RenderStates Default()
-	{
-		RenderStates temp;//make a static variable?
-
-		temp.m_texture = emptyTexture;
-		temp.m_shader = emptyShader;
-
-		return temp;
-	}
-
-	//Creates empty an epty texture and shader for continuous use to prevent
-	//creating them on the fly
-	package static Texture emptyTexture;
-	package static Shader emptyShader;
-
-	private static this()
-	{
-		emptyTexture = new Texture();
-		emptyShader = new Shader();
 	}
 }

--- a/src/dsfml/graphics/rendertarget.d
+++ b/src/dsfml/graphics/rendertarget.d
@@ -34,15 +34,15 @@ import dsfml.system.vector2;
 
 /++
  + Base class for all render targets (window, texture, ...)
- + 
+ +
  + RenderTarget defines the common behaviour of all the 2D render targets usable in the graphics module.
- + 
+ +
  + It makes it possible to draw 2D entities like sprites, shapes, text without using any OpenGL command directly.
- + 
+ +
  + A RenderTarget is also able to use views which are a kind of 2D cameras. With views you can globally scroll, rotate or zoom everything that is drawn, without having to transform every single entity.
- + 
+ +
  + On top of that, render targets are still able to render direct OpenGL stuff. It is even possible to mix together OpenGL calls and regular SFML drawing commands. When doing so, make sure that OpenGL states are not messed up by calling the pushGLStates/popGLStates functions.
- + 
+ +
  + Authors: Laurent Gomila, Jeremy DeHaan
  + See_Also: http://sfml-dev.org/documentation/2.0/classsf_1_1RenderTarget.php#details
  +/
@@ -50,50 +50,50 @@ interface RenderTarget
 {
 	/**
 	 * Change the current active view.
-	 * 
-	 * The view is like a 2D camera, it controls which part of the 2D scene is visible, and how it is viewed in the render-target. The new view will affect everything that is drawn, until another view is set. 
-	 * 
+	 *
+	 * The view is like a 2D camera, it controls which part of the 2D scene is visible, and how it is viewed in the render-target. The new view will affect everything that is drawn, until another view is set.
+	 *
 	 * The render target keeps its own copy of the view object, so it is not necessary to keep the original one alive after calling this function. To restore the original view of the target, you can pass the result of getDefaultView() to this function.
 	 */
 	@property
 	{
 		const(View) view(const(View) newView);
 		const(View) view() const;
-	}  
+	}
 
 	/**
 	 * Get the default view of the render target.
-	 * 
+	 *
 	 * The default view has the initial size of the render target, and never changes after the target has been created.
-	 * 
+	 *
 	 * Returns: The default view of the render target.
 	 */
 	const(View) getDefaultView() const; // note: if refactored, change documentation of view property above
 
 	/**
 	 * Return the size of the rendering region of the target.
-	 * 
+	 *
 	 * Returns: Size in pixels
 	 */
 	Vector2u getSize() const;
 
 	/**
 	 * Get the viewport of a view, applied to this render target.
-	 * 
+	 *
 	 * The viewport is defined in the view as a ratio, this function simply applies this ratio to the current dimensions of the render target to calculate the pixels rectangle that the viewport actually covers in the target.
-	 * 
+	 *
 	 * Params:
 	 * 		view	= The view for which we want to compute the viewport
-	 * 
+	 *
 	 * Returns: Viewport rectangle, expressed in pixels
 	 */
 	IntRect getViewport(const(View) view) const;
 
 	/**
 	 * Clear the entire target with a single color.
-	 * 
+	 *
 	 * This function is usually called once every frame, to clear the previous contents of the target.
-	 * 
+	 *
 	 * Params:
 	 * 		color	= Fill color to use to clear the render target
 	 */
@@ -101,106 +101,106 @@ interface RenderTarget
 
 	/**
 	 * Draw a drawable object to the render target.
-	 * 
+	 *
 	 * Params:
 	 * 		drawable	= Object to draw
 	 * 		states		= Render states to use for drawing
 	 */
-	void draw(Drawable drawable, RenderStates states = RenderStates.Default);
+	void draw(Drawable drawable, RenderStates states = RenderStates.init);
 
 	/**
 	 * Draw primitives defined by an array of vertices.
-	 * 
+	 *
 	 * Params:
 	 * 		vertices	= Array of vertices to draw
 	 * 		type		= Type of primitives to draw
 	 * 		states		= Render states to use for drawing
 	 */
-	void draw(const(Vertex)[] vertices, PrimitiveType type, RenderStates states = RenderStates.Default);
+	void draw(const(Vertex)[] vertices, PrimitiveType type, RenderStates states = RenderStates.init);
 
 	/**
 	 * Convert a point fom target coordinates to world coordinates, using the current view.
-	 * 
+	 *
 	 * This function is an overload of the mapPixelToCoords function that implicitely uses the current view.
-	 * 
+	 *
 	 * Params:
 	 * 		point	= Pixel to convert
-	 * 
+	 *
 	 * Returns: The converted point, in "world" coordinates.
 	 */
 	Vector2f mapPixelToCoords(Vector2i point) const;
 
 	/**
 	 * Convert a point from target coordinates to world coordinates.
-	 * 
+	 *
 	 * This function finds the 2D position that matches the given pixel of the render-target. In other words, it does the inverse of what the graphics card does, to find the initial position of a rendered pixel.
-	 * 
+	 *
 	 * Initially, both coordinate systems (world units and target pixels) match perfectly. But if you define a custom view or resize your render-target, this assertion is not true anymore, ie. a point located at (10, 50) in your render-target may map to the point (150, 75) in your 2D world – if the view is translated by (140, 25).
-	 * 
+	 *
 	 * For render-windows, this function is typically used to find which point (or object) is located below the mouse cursor.
-	 * 
+	 *
 	 * This version uses a custom view for calculations, see the other overload of the function if you want to use the current view of the render-target.
-	 * 
+	 *
 	 * Params:
 	 * 		point	= Pixel to convert
 	 * 		view	= The view to use for converting the point
-	 * 
+	 *
 	 * Returns: The converted point, in "world" coordinates.
 	 */
 	Vector2f mapPixelToCoords(Vector2i point, const(View) view) const;
 
 	/**
 	 * Convert a point from target coordinates to world coordinates, using the current view.
-	 * 
+	 *
 	 * This function is an overload of the mapPixelToCoords function that implicitely uses the current view.
-	 * 
+	 *
 	 * Params:
 	 * 		point	= Point to convert
-	 * 
+	 *
 	 * The converted point, in "world" coordinates
 	 */
 	Vector2i mapCoordsToPixel(Vector2f point) const;
 
 	/**
 	 * Convert a point from world coordinates to target coordinates.
-	 * 
+	 *
 	 * This function finds the pixel of the render-target that matches the given 2D point. In other words, it goes through the same process as the graphics card, to compute the final position of a rendered point.
-	 * 
+	 *
 	 * Initially, both coordinate systems (world units and target pixels) match perfectly. But if you define a custom view or resize your render-target, this assertion is not true anymore, ie. a point located at (150, 75) in your 2D world may map to the pixel (10, 50) of your render-target – if the view is translated by (140, 25).
-	 * 
+	 *
 	 * This version uses a custom view for calculations, see the other overload of the function if you want to use the current view of the render-target.
-	 * 
+	 *
 	 * Params:
 	 * 		point	= Point to convert
 	 * 		view	= The view to use for converting the point
-	 * 
+	 *
 	 * Returns: The converted point, in target coordinates (pixels)
 	 */
 	Vector2i mapCoordsToPixel(Vector2f point, const(View) view) const;
 
 	/**
 	 * Restore the previously saved OpenGL render states and matrices.
-	 * 
+	 *
 	 * See the description of pushGLStates to get a detailed description of these functions.
 	 */
 	void popGLStates();
 
 	/**
 	 * Save the current OpenGL render states and matrices.
-	 * 
+	 *
 	 * This function can be used when you mix SFML drawing and direct OpenGL rendering. Combined with PopGLStates, it ensures that:
 	 * - SFML's internal states are not messed up by your OpenGL code
 	 * - your OpenGL states are not modified by a call to an SFML function
-	 * 
+	 *
 	 * More specifically, it must be used around the code that calls Draw functions.
-	 * 
+	 *
 	 * Note that this function is quite expensive: it saves all the possible OpenGL states and matrices, even the ones you don't care about. Therefore it should be used wisely. It is provided for convenience, but the best results will be achieved if you handle OpenGL states yourself (because you know which states have really changed, and need to be saved and restored). Take a look at the ResetGLStates function if you do so.
 	 */
 	void pushGLStates();
 
 	/**
 	 * Reset the internal OpenGL states so that the target is ready for drawing.
-	 * 
+	 *
 	 * This function can be used when you mix SFML drawing and direct OpenGL rendering, if you choose not to use pushGLStates/popGLStates. It makes sure that all OpenGL states needed by SFML are set, so that subsequent draw() calls will work as expected.
 	 */
 	void resetGLStates();

--- a/src/dsfml/graphics/rendertexture.d
+++ b/src/dsfml/graphics/rendertexture.d
@@ -240,18 +240,8 @@ class RenderTexture : RenderTarget
 	 * 		drawable	= Object to draw
 	 * 		states		= Render states to use for drawing
 	 */
-	override void draw(Drawable drawable, RenderStates states = RenderStates.Default)
+	override void draw(Drawable drawable, RenderStates states = RenderStates.init)
 	{
-		//Confirms that even a blank render states struct won't break anything during drawing
-		if(states.texture is null)
-		{
-			states.texture = RenderStates.emptyTexture;
-		}
-		if(states.shader is null)
-		{
-			states.shader = RenderStates.emptyShader;
-		}
-
 		drawable.draw(this, states);
 	}
 
@@ -263,23 +253,13 @@ class RenderTexture : RenderTarget
 	 * 		type		= Type of primitives to draw
 	 * 		states		= Render states to use for drawing
 	 */
-	override void draw(const(Vertex)[] vertices, PrimitiveType type, RenderStates states = RenderStates.Default)
+	override void draw(const(Vertex)[] vertices, PrimitiveType type, RenderStates states = RenderStates.init)
 	{
 		import std.algorithm;
 
-		//Confirms that even a blank render states struct won't break anything during drawing
-		if(states.texture is null)
-		{
-			states.texture = RenderStates.emptyTexture;
-		}
-		if(states.shader is null)
-		{
-			states.shader = RenderStates.emptyShader;
-		}
-
 		sfRenderTexture_drawPrimitives(sfPtr, vertices.ptr, cast(uint)min(uint.max, vertices.length),type,states.blendMode.colorSrcFactor, states.blendMode.alphaDstFactor,
 			states.blendMode.colorEquation, states.blendMode.alphaSrcFactor, states.blendMode.alphaDstFactor, states.blendMode.alphaEquation,
-			states.transform.m_matrix.ptr, states.texture.sfPtr, states.shader.sfPtr);
+			states.transform.m_matrix.ptr, states.texture?states.texture.sfPtr:null, states.shader?states.shader.sfPtr:null);
 	}
 
 	/**

--- a/src/dsfml/graphics/renderwindow.d
+++ b/src/dsfml/graphics/renderwindow.d
@@ -74,7 +74,7 @@ class RenderWindow : Window, RenderTarget
 	}
 
 	//in order to envoke this constructor when using string literals, be sure to use the d suffix, i.e. "素晴らしい ！"d
-	this(T)(VideoMode mode, immutable(T)[] title, Style style = Style.DefaultStyle, ref const(ContextSettings) settings = ContextSettings.Default)
+	this(T)(VideoMode mode, immutable(T)[] title, Style style = Style.DefaultStyle, ContextSettings settings = ContextSettings.init)
 		if (is(T == dchar)||is(T == wchar)||is(T == char))
 	{
 
@@ -82,7 +82,7 @@ class RenderWindow : Window, RenderTarget
 		create(mode, title, style, settings);
 	}
 
-	this(WindowHandle handle, ref const(ContextSettings) settings = ContextSettings.Default)
+	this(WindowHandle handle, ContextSettings settings = ContextSettings.init)
 	{
 		this();
 		create(handle, settings);
@@ -416,7 +416,7 @@ class RenderWindow : Window, RenderTarget
 	///If the window was already created, it closes it first. If style contains Style::Fullscreen, then mode must be a valid video mode.
 	///
 	///The fourth parameter is an optional structure specifying advanced OpenGL context settings such as antialiasing, depth-buffer bits, etc.
-	override void create(VideoMode mode, const(char)[] title, Style style = Style.DefaultStyle, ref const(ContextSettings) settings = ContextSettings.Default)
+	override void create(VideoMode mode, const(char)[] title, Style style = Style.DefaultStyle, ContextSettings settings = ContextSettings.init)
 	{
 		import dsfml.system.string;
 
@@ -437,7 +437,7 @@ class RenderWindow : Window, RenderTarget
 	///If the window was already created, it closes it first. If style contains Style::Fullscreen, then mode must be a valid video mode.
 	///
 	///The fourth parameter is an optional structure specifying advanced OpenGL context settings such as antialiasing, depth-buffer bits, etc.
-	override void create(VideoMode mode, const(wchar)[] title, Style style = Style.DefaultStyle, ref const(ContextSettings) settings = ContextSettings.Default)
+	override void create(VideoMode mode, const(wchar)[] title, Style style = Style.DefaultStyle, ContextSettings settings = ContextSettings.init)
 	{
 		import dsfml.system.string;
 		auto convertedTitle = stringConvert!(wchar, dchar)(title);
@@ -457,7 +457,7 @@ class RenderWindow : Window, RenderTarget
 	///If the window was already created, it closes it first. If style contains Style::Fullscreen, then mode must be a valid video mode.
 	///
 	///The fourth parameter is an optional structure specifying advanced OpenGL context settings such as antialiasing, depth-buffer bits, etc.
-	override void create(VideoMode mode, const(dchar)[] title, Style style = Style.DefaultStyle, ref const(ContextSettings) settings = ContextSettings.Default)
+	override void create(VideoMode mode, const(dchar)[] title, Style style = Style.DefaultStyle, ContextSettings settings = ContextSettings.init)
 	{
 		import dsfml.system.string;
 		sfRenderWindow_createFromSettings(sfPtr, mode.width, mode.height, mode.bitsPerPixel, title.ptr, title.length, style, settings.depthBits, settings.stencilBits, settings.antialiasingLevel, settings.majorVersion, settings.minorVersion);
@@ -476,7 +476,7 @@ class RenderWindow : Window, RenderTarget
 	///Use this function if you want to create an OpenGL rendering area into an already existing control. If the window was already created, it closes it first.
 	///
 	///The second parameter is an optional structure specifying advanced OpenGL context settings such as antialiasing, depth-buffer bits, etc.
-	override void create(WindowHandle handle, ref const(ContextSettings) settings = ContextSettings.Default)
+	override void create(WindowHandle handle, ContextSettings settings = ContextSettings.init)
 	{
 		import dsfml.system.string;
 		sfRenderWindow_createFromHandle(sfPtr, handle, settings.depthBits,settings.stencilBits, settings.antialiasingLevel, settings.majorVersion, settings.minorVersion);
@@ -505,18 +505,8 @@ class RenderWindow : Window, RenderTarget
 	 * 		drawable	= Object to draw
 	 * 		states		= Render states to use for drawing
 	 */
-	void draw(Drawable drawable, RenderStates states = RenderStates.Default)
+	void draw(Drawable drawable, RenderStates states = RenderStates.init)
 	{
-		//Confirms that even a blank render states struct won't break anything during drawing
-		if(states.texture is null)
-		{
-			states.texture = RenderStates.emptyTexture;
-		}
-		if(states.shader is null)
-		{
-			states.shader = RenderStates.emptyShader;
-		}
-
 		drawable.draw(this,states);
 	}
 
@@ -528,22 +518,13 @@ class RenderWindow : Window, RenderTarget
 	 * 		type		= Type of primitives to draw
 	 * 		states		= Render states to use for drawing
 	 */
-	void draw(const(Vertex)[] vertices, PrimitiveType type, RenderStates states = RenderStates.Default)
+	void draw(const(Vertex)[] vertices, PrimitiveType type, RenderStates states = RenderStates.init)
 	{
 		import std.algorithm;
-		//Confirms that even a blank render states struct won't break anything during drawing
-		if(states.texture is null)
-		{
-			states.texture = RenderStates.emptyTexture;
-		}
-		if(states.shader is null)
-		{
-			states.shader = RenderStates.emptyShader;
-		}
 
 		sfRenderWindow_drawPrimitives(sfPtr, vertices.ptr, cast(uint)min(uint.max, vertices.length), type,states.blendMode.colorSrcFactor, states.blendMode.alphaDstFactor,
 			states.blendMode.colorEquation, states.blendMode.alphaSrcFactor, states.blendMode.alphaDstFactor, states.blendMode.alphaEquation,
-			states.transform.m_matrix.ptr,states.texture.sfPtr,states.shader.sfPtr);
+			states.transform.m_matrix.ptr,states.texture?states.texture.sfPtr:null,states.shader?states.shader.sfPtr:null);
 	}
 
 	/**

--- a/src/dsfml/graphics/shader.d
+++ b/src/dsfml/graphics/shader.d
@@ -438,14 +438,14 @@ class Shader
 	void setParameter(const(char)[] name, const(Texture) texture)
 	{
 		import dsfml.system.string;
-		sfShader_setTextureParameter(sfPtr, name.ptr, name.length, texture.sfPtr);
+		sfShader_setTextureParameter(sfPtr, name.ptr, name.length, texture?texture.sfPtr:null);
 		err.write(dsfml.system.string.toString(sfErr_getOutput()));
 	}
 	///ditto
 	void opIndexAssign(const(Texture) texture, const(char)[] name)
 	{
 		import dsfml.system.string;
-		sfShader_setTextureParameter(sfPtr, name.ptr, name.length, texture.sfPtr);
+		sfShader_setTextureParameter(sfPtr, name.ptr, name.length, texture?texture.sfPtr:null);
 		err.write(dsfml.system.string.toString(sfErr_getOutput()));
 	}
 

--- a/src/dsfml/window/contextsettings.d
+++ b/src/dsfml/window/contextsettings.d
@@ -25,7 +25,7 @@ module dsfml.window.contextsettings;
  *
  *ContextSettings allows to define several advanced settings of the OpenGL context attached to a window.
  *
- *All these settings have no impact on the regular SFML rendering (graphics module) – except the 
+ *All these settings have no impact on the regular SFML rendering (graphics module) – except the
  *anti-aliasing level, so you may need to use this structure only if you're using SFML as a windowing system for custom OpenGL rendering.
  *
  *The depthBits and stencilBits members define the number of bits per pixel requested for the (respectively) depth and stencil buffers.
@@ -33,12 +33,12 @@ module dsfml.window.contextsettings;
  *antialiasingLevel represents the requested number of multisampling levels for anti-aliasing.
  *
  *majorVersion and minorVersion define the version of the OpenGL context that you want. Only versions
- *greater or equal to 3.0 are relevant; versions lesser than 3.0 are all handled the same way (i.e. you 
+ *greater or equal to 3.0 are relevant; versions lesser than 3.0 are all handled the same way (i.e. you
  *(can use any version < 3.0 if you don't want an OpenGL 3 context).
  *
- *Please note that these values are only a hint. No failure will be reported if one or more of these 
- *values are not supported by the system; instead, SFML will try to find the closest valid match. 
- *You can then retrieve the settings that the window actually used to create its context, with Window.getSettings(). 
+ *Please note that these values are only a hint. No failure will be reported if one or more of these
+ *values are not supported by the system; instead, SFML will try to find the closest valid match.
+ *You can then retrieve the settings that the window actually used to create its context, with Window.getSettings().
  */
 struct ContextSettings
 {
@@ -52,7 +52,5 @@ struct ContextSettings
 	uint majorVersion = 2;
 	///Minor number of the context version to create.
 	uint minorVersion = 0;
-	
-	static const(ContextSettings) Default;
 }
 //unittest?

--- a/src/dsfml/window/window.d
+++ b/src/dsfml/window/window.d
@@ -92,7 +92,7 @@ class Window
 	///  	title = Title of the window.
 	///   	style = Window style.
 	///    	settings = Additional settings for the underlying OpenGL context.
-	this(T)(VideoMode mode, immutable(T)[] title, Style style = Style.DefaultStyle, ref const(ContextSettings) settings = ContextSettings.Default)
+	this(T)(VideoMode mode, immutable(T)[] title, Style style = Style.DefaultStyle, ContextSettings settings = ContextSettings.init)
 		if (is(T == dchar)||is(T == wchar)||is(T == char))
 	{
 		this();
@@ -108,7 +108,7 @@ class Window
 	///Params:
     ///		handle = Platform-specific handle of the control.
     ///		settings = Additional settings for the underlying OpenGL context.
-	this(WindowHandle handle, ref const(ContextSettings) settings = ContextSettings.Default)
+	this(WindowHandle handle, ContextSettings settings = ContextSettings.init)
 	{
 		this();
 		create(handle, settings);
@@ -351,7 +351,7 @@ class Window
 	///If the window was already created, it closes it first. If style contains Style::Fullscreen, then mode must be a valid video mode.
 	///
 	///The fourth parameter is an optional structure specifying advanced OpenGL context settings such as antialiasing, depth-buffer bits, etc.
-	void create(VideoMode mode, const(char)[] title, Style style = Style.DefaultStyle, ref const(ContextSettings) settings = ContextSettings.Default)
+	void create(VideoMode mode, const(char)[] title, Style style = Style.DefaultStyle, ContextSettings settings = ContextSettings.init)
 	{
 		import dsfml.system.string;
 
@@ -364,7 +364,7 @@ class Window
 	///If the window was already created, it closes it first. If style contains Style::Fullscreen, then mode must be a valid video mode.
 	///
 	///The fourth parameter is an optional structure specifying advanced OpenGL context settings such as antialiasing, depth-buffer bits, etc.
-	void create(VideoMode mode, const(wchar)[] title, Style style = Style.DefaultStyle, ref const(ContextSettings) settings = ContextSettings.Default)
+	void create(VideoMode mode, const(wchar)[] title, Style style = Style.DefaultStyle, ContextSettings settings = ContextSettings.init)
 	{
 		import dsfml.system.string;
 		auto convertedTitle = stringConvert!(wchar,dchar)(title);
@@ -376,7 +376,7 @@ class Window
 	///If the window was already created, it closes it first. If style contains Style::Fullscreen, then mode must be a valid video mode.
 	///
 	///The fourth parameter is an optional structure specifying advanced OpenGL context settings such as antialiasing, depth-buffer bits, etc.
-	void create(VideoMode mode, const(dchar)[] title, Style style = Style.DefaultStyle, ref const(ContextSettings) settings = ContextSettings.Default)
+	void create(VideoMode mode, const(dchar)[] title, Style style = Style.DefaultStyle, ContextSettings settings = ContextSettings.init)
 	{
 		import dsfml.system.string;
 		sfWindow_createFromSettings(sfPtr, mode.width, mode.height, mode.bitsPerPixel, title.ptr, title.length, style, settings.depthBits, settings.stencilBits, settings.antialiasingLevel, settings.majorVersion, settings.minorVersion);
@@ -388,7 +388,7 @@ class Window
 	///Use this function if you want to create an OpenGL rendering area into an already existing control. If the window was already created, it closes it first.
 	///
 	///The second parameter is an optional structure specifying advanced OpenGL context settings such as antialiasing, depth-buffer bits, etc.
-	void create(WindowHandle handle, ref const(ContextSettings) settings = ContextSettings.Default)
+	void create(WindowHandle handle, ContextSettings settings = ContextSettings.init)
 	{
 		import dsfml.system.string;
 		sfWindow_createFromHandle(sfPtr, handle, settings.depthBits,settings.stencilBits, settings.antialiasingLevel, settings.majorVersion, settings.minorVersion);


### PR DESCRIPTION
A couple cleanups here

-First and foremost, I've added null checks to anything that accesses the sfPtr of Texture and Shader, allowing those to be null in a RenderStates without issue. This means we don't need emptyTexture and emptyShader at all. 
-Second, we pass ContextSettings to window creation methods by value instead of reference. This eliminates the need for ContextSettings.Default, and should fix #227 
-Finally, I've replaced the C++ calls in two of the IpAddress constructors; creating an IpAddress ubyte[4] and uint is trivial and doesn't require any network calls so it's easily done on the D-side. This eliminates the need for the static constructor here too. It does unfortunately need phobos for std.string.sformat however, as sprintf is a C call and thus not doable with CTFE.
