### PR TITLE
Convert View to a struct, D-Side

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>DSFML</name>
+	<comment></comment>
+	<projects>
+		<project>DSFMLC</project>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.dsource.ddt.ide.core.DubBuilder</name>
+			<triggers>clean,full,incremental,</triggers>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.dsource.ddt.ide.core.nature</nature>
+	</natures>
+</projectDescription>

--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
 #Build and install DSFMLC
 install:
   - cd $HOME
-  - git clone --depth=1 --branch 2.3 https://github.com/Jebbs/DSFMLC.git
+  - git clone --depth=1 --branch 2.3-dview https://github.com/aubade/DSFMLC.git
   - cd DSFMLC
   - cmake .
   - make -j2

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -187,7 +187,7 @@ build_script:
 - echo %VCINSTALLDIR%
 - '"%compilersetup%" %compilersetupargs%'
 - cd ..
-- git clone --depth=1 --branch 2.3 https://github.com/Jebbs/DSFMLC.git
+- git clone --depth=1 --branch 2.3-dview https://github.com/aubade/DSFMLC.git
 - cd DSFMLC
 - ps: if($env:toolchain -eq "mingw"){
         $env:Path = $env:compilerpath + $env:cmakepath;

--- a/src/dsfml/graphics/renderstates.d
+++ b/src/dsfml/graphics/renderstates.d
@@ -27,23 +27,23 @@ import std.typecons:Rebindable;
 
 /++
  + Define the states used for drawing to a RenderTarget.
- + 
+ +
  + There are four global states that can be applied to the drawn objects:
  + - the blend mode: how pixels of the object are blended with the background
  + - the transform: how the object is positioned/rotated/scaled
  + - the texture: what image is mapped to the object
  + - the shader: what custom effect is applied to the object
- + 
+ +
  + High-level objects such as sprites or text force some of these states when they are drawn. For example, a sprite will set its own texture, so that you don't have to care about it when drawing the sprite.
- + 
+ +
  + The transform is a special case: sprites, texts and shapes (and it's a good idea to do it with your own drawable classes too) combine their transform with the one that is passed in the RenderStates structure. So that you can use a "global" transform on top of each object's transform.
- + 
+ +
  + Most objects, especially high-level drawables, can be drawn directly without defining render states explicitely – the default set of states is ok in most cases.
- + 
+ +
  + If you want to use a single specific render state, for example a shader, you can pass it directly to the Draw function: RenderStates has an implicit one-argument constructor for each state.
- + 
+ +
  + When you're inside the Draw function of a drawable object (inherited from sf::Drawable), you can either pass the render states unmodified, or change some of them. For example, a transformable object will combine the current transform with its own transform. A sprite will set its texture. Etc.
- + 
+ +
  + Authors: Laurent Gomila, Jeremy DeHaan
  + See_Also: http://www.sfml-dev.org/documentation/2.0/classsf_1_1RenderStates.php#details
  +/
@@ -62,8 +62,8 @@ struct RenderStates
 		blendMode = theBlendMode;
 		transform = Transform();
 
-		m_texture = emptyTexture;
-		m_shader = emptyShader;
+		m_texture = null;
+		m_shader = null;
 
 	}
 
@@ -73,61 +73,31 @@ struct RenderStates
 
 		blendMode = BlendMode.Alpha;
 
-		m_texture = emptyTexture;
-		m_shader = emptyShader;
+		m_texture = null;
+		m_shader = null;
 	}
 
 	this(const(Texture) theTexture)
 	{
-		if(theTexture !is null)
-		{
-			
-			m_texture = theTexture;
-		}
-		else
-		{
-			m_texture = emptyTexture;
-		}
+		m_texture = theTexture;
 
 		blendMode = BlendMode.Alpha;
 
 		transform = Transform();
-		m_shader = emptyShader;
+		m_shader = null;
 	}
 
 	this(const(Shader) theShader)
 	{
-		if(theShader !is null)
-		{
-			m_shader = theShader;
-		}
-		else
-		{
-			m_shader = emptyShader;
-		}
+		m_shader = theShader;
 	}
 
 	this(BlendMode theBlendMode, Transform theTransform, const(Texture) theTexture, const(Shader) theShader)
 	{
 		blendMode = theBlendMode;
 		transform = theTransform;
-		if(theTexture !is null)
-		{
-			
-			m_texture = theTexture;
-		}
-		else
-		{
-			m_texture = emptyTexture;
-		}
-		if(theShader !is null)
-		{
-			m_shader = theShader;
-		}
-		else
-		{
-			m_shader = emptyShader;
-		}
+		m_texture = theTexture;
+		m_shader = theShader;
 	}
 
 	/// The shader to apply while rendering.
@@ -135,14 +105,7 @@ struct RenderStates
 	{
 		const(Shader) shader(const(Shader) theShader)
 		{
-			if(theShader !is null)
-			{
-				m_shader = theShader;
-			}
-			else
-			{
-				m_shader = emptyShader;
-			}
+			m_shader = theShader;
 			return theShader;
 		}
 		const(Shader) shader()
@@ -156,43 +119,12 @@ struct RenderStates
 	{
 		const(Texture) texture(const(Texture) theTexture)
 		{
-			if(theTexture !is null)
-			{
-				
-				m_texture = theTexture;
-			}
-			else
-			{
-				m_texture = emptyTexture;
-			}
+			m_texture = theTexture;
 			return theTexture;
 		}
 		const(Texture) texture()
 		{
 			return m_texture;
 		}
-	}
-
-	/// A default, empty render state.
-	@property
-	static RenderStates Default()
-	{
-		RenderStates temp;//make a static variable?
-
-		temp.m_texture = emptyTexture;
-		temp.m_shader = emptyShader;
-
-		return temp;
-	}
-
-	//Creates empty an epty texture and shader for continuous use to prevent
-	//creating them on the fly
-	package static Texture emptyTexture;
-	package static Shader emptyShader;
-
-	private static this()
-	{
-		emptyTexture = new Texture();
-		emptyShader = new Shader();
 	}
 }

--- a/src/dsfml/graphics/rendertarget.d
+++ b/src/dsfml/graphics/rendertarget.d
@@ -57,8 +57,8 @@ interface RenderTarget
 	 */
 	@property
 	{
-		const(View) view(const(View) newView);
-		const(View) view() const;
+		View view(View newView);
+		View view() const;
 	}
 
 	/**
@@ -68,7 +68,7 @@ interface RenderTarget
 	 *
 	 * Returns: The default view of the render target.
 	 */
-	const(View) getDefaultView() const; // note: if refactored, change documentation of view property above
+	View getDefaultView() const; // note: if refactored, change documentation of view property above
 
 	/**
 	 * Return the size of the rendering region of the target.
@@ -87,7 +87,16 @@ interface RenderTarget
 	 *
 	 * Returns: Viewport rectangle, expressed in pixels
 	 */
-	IntRect getViewport(const(View) view) const;
+	final IntRect getViewport(View view) const
+	{
+		float width = getSize().x;
+		float height = getSize().y;
+
+		return IntRect(cast(int)(0.5 + width * view.viewport.left),
+						cast(int)(0.5 + height * view.viewport.top),
+						cast(int)(0.5 + width * view.viewport.width),
+						cast(int)(0.5 + height * view.viewport.height));
+	}
 
 	/**
 	 * Clear the entire target with a single color.
@@ -128,7 +137,11 @@ interface RenderTarget
 	 *
 	 * Returns: The converted point, in "world" coordinates.
 	 */
-	Vector2f mapPixelToCoords(Vector2i point) const;
+	//these methods are marked inout because const Views can't cache transforms.
+	final Vector2f mapPixelToCoords(Vector2i point) inout
+	{
+		return mapPixelToCoords(point, view);
+	}
 
 	/**
 	 * Convert a point from target coordinates to world coordinates.
@@ -147,10 +160,20 @@ interface RenderTarget
 	 *
 	 * Returns: The converted point, in "world" coordinates.
 	 */
-	Vector2f mapPixelToCoords(Vector2i point, const(View) view) const;
+	final Vector2f mapPixelToCoords(Vector2i point, View theView) inout
+	{
+	    // First, convert from viewport coordinates to homogeneous coordinates
+		Vector2f normalized;
+
+		normalized.x = -1.0 + 2.0 * (cast(float)point.x - theView.viewport.left) / theView.viewport.width;
+		normalized.y = -1.0 + 2.0 * (cast(float)point.y - theView.viewport.top) / theView.viewport.height;
+
+	    // Then transform by the inverse of the view matrix
+		return view.getInverseTransform().transformPoint(normalized);
+	}
 
 	/**
-	 * Convert a point from target coordinates to world coordinates, using the current view.
+	 * Convert a point from target coordinates to world coordinates, using the curtheView.view.
 	 *
 	 * This function is an overload of the mapPixelToCoords function that implicitely uses the current view.
 	 *
@@ -159,7 +182,10 @@ interface RenderTarget
 	 *
 	 * The converted point, in "world" coordinates
 	 */
-	Vector2i mapCoordsToPixel(Vector2f point) const;
+	final Vector2i mapCoordsToPixel(Vector2f point) inout
+	{
+		return mapCoordsToPixel(point, view);
+	}
 
 	/**
 	 * Convert a point from world coordinates to target coordinates.
@@ -176,7 +202,18 @@ interface RenderTarget
 	 *
 	 * Returns: The converted point, in target coordinates (pixels)
 	 */
-	Vector2i mapCoordsToPixel(Vector2f point, const(View) view) const;
+	final Vector2i mapCoordsToPixel(Vector2f point, View theView) inout
+	{
+		// First, transform the point by the view matrix
+		Vector2f normalized = theView.getTransform().transformPoint(point);
+
+		// Then convert to viewport coordinates
+		Vector2i pixel;
+		pixel.x = cast(int)(( normalized.x + 1.0) / 2.0 * theView.viewport.width  + theView.viewport.left);
+		pixel.y = cast(int)((-normalized.y + 1.0) / 2.0 * theView.viewport.height + theView.viewport.top);
+
+		return pixel;
+	}
 
 	/**
 	 * Restore the previously saved OpenGL render states and matrices.

--- a/src/dsfml/graphics/rendertarget.d
+++ b/src/dsfml/graphics/rendertarget.d
@@ -34,15 +34,15 @@ import dsfml.system.vector2;
 
 /++
  + Base class for all render targets (window, texture, ...)
- + 
+ +
  + RenderTarget defines the common behaviour of all the 2D render targets usable in the graphics module.
- + 
+ +
  + It makes it possible to draw 2D entities like sprites, shapes, text without using any OpenGL command directly.
- + 
+ +
  + A RenderTarget is also able to use views which are a kind of 2D cameras. With views you can globally scroll, rotate or zoom everything that is drawn, without having to transform every single entity.
- + 
+ +
  + On top of that, render targets are still able to render direct OpenGL stuff. It is even possible to mix together OpenGL calls and regular SFML drawing commands. When doing so, make sure that OpenGL states are not messed up by calling the pushGLStates/popGLStates functions.
- + 
+ +
  + Authors: Laurent Gomila, Jeremy DeHaan
  + See_Also: http://sfml-dev.org/documentation/2.0/classsf_1_1RenderTarget.php#details
  +/
@@ -50,50 +50,50 @@ interface RenderTarget
 {
 	/**
 	 * Change the current active view.
-	 * 
-	 * The view is like a 2D camera, it controls which part of the 2D scene is visible, and how it is viewed in the render-target. The new view will affect everything that is drawn, until another view is set. 
-	 * 
+	 *
+	 * The view is like a 2D camera, it controls which part of the 2D scene is visible, and how it is viewed in the render-target. The new view will affect everything that is drawn, until another view is set.
+	 *
 	 * The render target keeps its own copy of the view object, so it is not necessary to keep the original one alive after calling this function. To restore the original view of the target, you can pass the result of getDefaultView() to this function.
 	 */
 	@property
 	{
 		const(View) view(const(View) newView);
 		const(View) view() const;
-	}  
+	}
 
 	/**
 	 * Get the default view of the render target.
-	 * 
+	 *
 	 * The default view has the initial size of the render target, and never changes after the target has been created.
-	 * 
+	 *
 	 * Returns: The default view of the render target.
 	 */
 	const(View) getDefaultView() const; // note: if refactored, change documentation of view property above
 
 	/**
 	 * Return the size of the rendering region of the target.
-	 * 
+	 *
 	 * Returns: Size in pixels
 	 */
 	Vector2u getSize() const;
 
 	/**
 	 * Get the viewport of a view, applied to this render target.
-	 * 
+	 *
 	 * The viewport is defined in the view as a ratio, this function simply applies this ratio to the current dimensions of the render target to calculate the pixels rectangle that the viewport actually covers in the target.
-	 * 
+	 *
 	 * Params:
 	 * 		view	= The view for which we want to compute the viewport
-	 * 
+	 *
 	 * Returns: Viewport rectangle, expressed in pixels
 	 */
 	IntRect getViewport(const(View) view) const;
 
 	/**
 	 * Clear the entire target with a single color.
-	 * 
+	 *
 	 * This function is usually called once every frame, to clear the previous contents of the target.
-	 * 
+	 *
 	 * Params:
 	 * 		color	= Fill color to use to clear the render target
 	 */
@@ -101,106 +101,106 @@ interface RenderTarget
 
 	/**
 	 * Draw a drawable object to the render target.
-	 * 
+	 *
 	 * Params:
 	 * 		drawable	= Object to draw
 	 * 		states		= Render states to use for drawing
 	 */
-	void draw(Drawable drawable, RenderStates states = RenderStates.Default);
+	void draw(Drawable drawable, RenderStates states = RenderStates.init);
 
 	/**
 	 * Draw primitives defined by an array of vertices.
-	 * 
+	 *
 	 * Params:
 	 * 		vertices	= Array of vertices to draw
 	 * 		type		= Type of primitives to draw
 	 * 		states		= Render states to use for drawing
 	 */
-	void draw(const(Vertex)[] vertices, PrimitiveType type, RenderStates states = RenderStates.Default);
+	void draw(const(Vertex)[] vertices, PrimitiveType type, RenderStates states = RenderStates.init);
 
 	/**
 	 * Convert a point fom target coordinates to world coordinates, using the current view.
-	 * 
+	 *
 	 * This function is an overload of the mapPixelToCoords function that implicitely uses the current view.
-	 * 
+	 *
 	 * Params:
 	 * 		point	= Pixel to convert
-	 * 
+	 *
 	 * Returns: The converted point, in "world" coordinates.
 	 */
 	Vector2f mapPixelToCoords(Vector2i point) const;
 
 	/**
 	 * Convert a point from target coordinates to world coordinates.
-	 * 
+	 *
 	 * This function finds the 2D position that matches the given pixel of the render-target. In other words, it does the inverse of what the graphics card does, to find the initial position of a rendered pixel.
-	 * 
+	 *
 	 * Initially, both coordinate systems (world units and target pixels) match perfectly. But if you define a custom view or resize your render-target, this assertion is not true anymore, ie. a point located at (10, 50) in your render-target may map to the point (150, 75) in your 2D world – if the view is translated by (140, 25).
-	 * 
+	 *
 	 * For render-windows, this function is typically used to find which point (or object) is located below the mouse cursor.
-	 * 
+	 *
 	 * This version uses a custom view for calculations, see the other overload of the function if you want to use the current view of the render-target.
-	 * 
+	 *
 	 * Params:
 	 * 		point	= Pixel to convert
 	 * 		view	= The view to use for converting the point
-	 * 
+	 *
 	 * Returns: The converted point, in "world" coordinates.
 	 */
 	Vector2f mapPixelToCoords(Vector2i point, const(View) view) const;
 
 	/**
 	 * Convert a point from target coordinates to world coordinates, using the current view.
-	 * 
+	 *
 	 * This function is an overload of the mapPixelToCoords function that implicitely uses the current view.
-	 * 
+	 *
 	 * Params:
 	 * 		point	= Point to convert
-	 * 
+	 *
 	 * The converted point, in "world" coordinates
 	 */
 	Vector2i mapCoordsToPixel(Vector2f point) const;
 
 	/**
 	 * Convert a point from world coordinates to target coordinates.
-	 * 
+	 *
 	 * This function finds the pixel of the render-target that matches the given 2D point. In other words, it goes through the same process as the graphics card, to compute the final position of a rendered point.
-	 * 
+	 *
 	 * Initially, both coordinate systems (world units and target pixels) match perfectly. But if you define a custom view or resize your render-target, this assertion is not true anymore, ie. a point located at (150, 75) in your 2D world may map to the pixel (10, 50) of your render-target – if the view is translated by (140, 25).
-	 * 
+	 *
 	 * This version uses a custom view for calculations, see the other overload of the function if you want to use the current view of the render-target.
-	 * 
+	 *
 	 * Params:
 	 * 		point	= Point to convert
 	 * 		view	= The view to use for converting the point
-	 * 
+	 *
 	 * Returns: The converted point, in target coordinates (pixels)
 	 */
 	Vector2i mapCoordsToPixel(Vector2f point, const(View) view) const;
 
 	/**
 	 * Restore the previously saved OpenGL render states and matrices.
-	 * 
+	 *
 	 * See the description of pushGLStates to get a detailed description of these functions.
 	 */
 	void popGLStates();
 
 	/**
 	 * Save the current OpenGL render states and matrices.
-	 * 
+	 *
 	 * This function can be used when you mix SFML drawing and direct OpenGL rendering. Combined with PopGLStates, it ensures that:
 	 * - SFML's internal states are not messed up by your OpenGL code
 	 * - your OpenGL states are not modified by a call to an SFML function
-	 * 
+	 *
 	 * More specifically, it must be used around the code that calls Draw functions.
-	 * 
+	 *
 	 * Note that this function is quite expensive: it saves all the possible OpenGL states and matrices, even the ones you don't care about. Therefore it should be used wisely. It is provided for convenience, but the best results will be achieved if you handle OpenGL states yourself (because you know which states have really changed, and need to be saved and restored). Take a look at the ResetGLStates function if you do so.
 	 */
 	void pushGLStates();
 
 	/**
 	 * Reset the internal OpenGL states so that the target is ready for drawing.
-	 * 
+	 *
 	 * This function can be used when you mix SFML drawing and direct OpenGL rendering, if you choose not to use pushGLStates/popGLStates. It makes sure that all OpenGL states needed by SFML are set, so that subsequent draw() calls will work as expected.
 	 */
 	void resetGLStates();

--- a/src/dsfml/graphics/rendertexture.d
+++ b/src/dsfml/graphics/rendertexture.d
@@ -240,18 +240,8 @@ class RenderTexture : RenderTarget
 	 * 		drawable	= Object to draw
 	 * 		states		= Render states to use for drawing
 	 */
-	override void draw(Drawable drawable, RenderStates states = RenderStates.Default)
+	override void draw(Drawable drawable, RenderStates states = RenderStates.init)
 	{
-		//Confirms that even a blank render states struct won't break anything during drawing
-		if(states.texture is null)
-		{
-			states.texture = RenderStates.emptyTexture;
-		}
-		if(states.shader is null)
-		{
-			states.shader = RenderStates.emptyShader;
-		}
-
 		drawable.draw(this, states);
 	}
 
@@ -263,23 +253,13 @@ class RenderTexture : RenderTarget
 	 * 		type		= Type of primitives to draw
 	 * 		states		= Render states to use for drawing
 	 */
-	override void draw(const(Vertex)[] vertices, PrimitiveType type, RenderStates states = RenderStates.Default)
+	override void draw(const(Vertex)[] vertices, PrimitiveType type, RenderStates states = RenderStates.init)
 	{
 		import std.algorithm;
 
-		//Confirms that even a blank render states struct won't break anything during drawing
-		if(states.texture is null)
-		{
-			states.texture = RenderStates.emptyTexture;
-		}
-		if(states.shader is null)
-		{
-			states.shader = RenderStates.emptyShader;
-		}
-
 		sfRenderTexture_drawPrimitives(sfPtr, vertices.ptr, cast(uint)min(uint.max, vertices.length),type,states.blendMode.colorSrcFactor, states.blendMode.alphaDstFactor,
 			states.blendMode.colorEquation, states.blendMode.alphaSrcFactor, states.blendMode.alphaDstFactor, states.blendMode.alphaEquation,
-			states.transform.m_matrix.ptr, states.texture.sfPtr, states.shader.sfPtr);
+			states.transform.m_matrix.ptr, states.texture?states.texture.sfPtr:null, states.shader?states.shader.sfPtr:null);
 	}
 
 	/**

--- a/src/dsfml/graphics/renderwindow.d
+++ b/src/dsfml/graphics/renderwindow.d
@@ -74,7 +74,7 @@ class RenderWindow : Window, RenderTarget
 	}
 
 	//in order to envoke this constructor when using string literals, be sure to use the d suffix, i.e. "素晴らしい ！"d
-	this(T)(VideoMode mode, immutable(T)[] title, Style style = Style.DefaultStyle, ref const(ContextSettings) settings = ContextSettings.Default)
+	this(T)(VideoMode mode, immutable(T)[] title, Style style = Style.DefaultStyle, ContextSettings settings = ContextSettings.init)
 		if (is(T == dchar)||is(T == wchar)||is(T == char))
 	{
 
@@ -82,7 +82,7 @@ class RenderWindow : Window, RenderTarget
 		create(mode, title, style, settings);
 	}
 
-	this(WindowHandle handle, ref const(ContextSettings) settings = ContextSettings.Default)
+	this(WindowHandle handle, ContextSettings settings = ContextSettings.init)
 	{
 		this();
 		create(handle, settings);
@@ -416,7 +416,7 @@ class RenderWindow : Window, RenderTarget
 	///If the window was already created, it closes it first. If style contains Style::Fullscreen, then mode must be a valid video mode.
 	///
 	///The fourth parameter is an optional structure specifying advanced OpenGL context settings such as antialiasing, depth-buffer bits, etc.
-	override void create(VideoMode mode, const(char)[] title, Style style = Style.DefaultStyle, ref const(ContextSettings) settings = ContextSettings.Default)
+	override void create(VideoMode mode, const(char)[] title, Style style = Style.DefaultStyle, ContextSettings settings = ContextSettings.init)
 	{
 		import dsfml.system.string;
 
@@ -437,7 +437,7 @@ class RenderWindow : Window, RenderTarget
 	///If the window was already created, it closes it first. If style contains Style::Fullscreen, then mode must be a valid video mode.
 	///
 	///The fourth parameter is an optional structure specifying advanced OpenGL context settings such as antialiasing, depth-buffer bits, etc.
-	override void create(VideoMode mode, const(wchar)[] title, Style style = Style.DefaultStyle, ref const(ContextSettings) settings = ContextSettings.Default)
+	override void create(VideoMode mode, const(wchar)[] title, Style style = Style.DefaultStyle, ContextSettings settings = ContextSettings.init)
 	{
 		import dsfml.system.string;
 		auto convertedTitle = stringConvert!(wchar, dchar)(title);
@@ -457,7 +457,7 @@ class RenderWindow : Window, RenderTarget
 	///If the window was already created, it closes it first. If style contains Style::Fullscreen, then mode must be a valid video mode.
 	///
 	///The fourth parameter is an optional structure specifying advanced OpenGL context settings such as antialiasing, depth-buffer bits, etc.
-	override void create(VideoMode mode, const(dchar)[] title, Style style = Style.DefaultStyle, ref const(ContextSettings) settings = ContextSettings.Default)
+	override void create(VideoMode mode, const(dchar)[] title, Style style = Style.DefaultStyle, ContextSettings settings = ContextSettings.init)
 	{
 		import dsfml.system.string;
 		sfRenderWindow_createFromSettings(sfPtr, mode.width, mode.height, mode.bitsPerPixel, title.ptr, title.length, style, settings.depthBits, settings.stencilBits, settings.antialiasingLevel, settings.majorVersion, settings.minorVersion);
@@ -476,7 +476,7 @@ class RenderWindow : Window, RenderTarget
 	///Use this function if you want to create an OpenGL rendering area into an already existing control. If the window was already created, it closes it first.
 	///
 	///The second parameter is an optional structure specifying advanced OpenGL context settings such as antialiasing, depth-buffer bits, etc.
-	override void create(WindowHandle handle, ref const(ContextSettings) settings = ContextSettings.Default)
+	override void create(WindowHandle handle, ContextSettings settings = ContextSettings.init)
 	{
 		import dsfml.system.string;
 		sfRenderWindow_createFromHandle(sfPtr, handle, settings.depthBits,settings.stencilBits, settings.antialiasingLevel, settings.majorVersion, settings.minorVersion);
@@ -505,18 +505,8 @@ class RenderWindow : Window, RenderTarget
 	 * 		drawable	= Object to draw
 	 * 		states		= Render states to use for drawing
 	 */
-	void draw(Drawable drawable, RenderStates states = RenderStates.Default)
+	void draw(Drawable drawable, RenderStates states = RenderStates.init)
 	{
-		//Confirms that even a blank render states struct won't break anything during drawing
-		if(states.texture is null)
-		{
-			states.texture = RenderStates.emptyTexture;
-		}
-		if(states.shader is null)
-		{
-			states.shader = RenderStates.emptyShader;
-		}
-
 		drawable.draw(this,states);
 	}
 
@@ -528,22 +518,13 @@ class RenderWindow : Window, RenderTarget
 	 * 		type		= Type of primitives to draw
 	 * 		states		= Render states to use for drawing
 	 */
-	void draw(const(Vertex)[] vertices, PrimitiveType type, RenderStates states = RenderStates.Default)
+	void draw(const(Vertex)[] vertices, PrimitiveType type, RenderStates states = RenderStates.init)
 	{
 		import std.algorithm;
-		//Confirms that even a blank render states struct won't break anything during drawing
-		if(states.texture is null)
-		{
-			states.texture = RenderStates.emptyTexture;
-		}
-		if(states.shader is null)
-		{
-			states.shader = RenderStates.emptyShader;
-		}
 
 		sfRenderWindow_drawPrimitives(sfPtr, vertices.ptr, cast(uint)min(uint.max, vertices.length), type,states.blendMode.colorSrcFactor, states.blendMode.alphaDstFactor,
 			states.blendMode.colorEquation, states.blendMode.alphaSrcFactor, states.blendMode.alphaDstFactor, states.blendMode.alphaEquation,
-			states.transform.m_matrix.ptr,states.texture.sfPtr,states.shader.sfPtr);
+			states.transform.m_matrix.ptr,states.texture?states.texture.sfPtr:null,states.shader?states.shader.sfPtr:null);
 	}
 
 	/**

--- a/src/dsfml/graphics/renderwindow.d
+++ b/src/dsfml/graphics/renderwindow.d
@@ -68,8 +68,6 @@ class RenderWindow : Window, RenderTarget
 	this()
 	{
 		sfPtr = sfRenderWindow_construct();
-		m_currentView = new View();
-		m_defaultView = new View();
 		super(0);
 	}
 
@@ -143,15 +141,29 @@ class RenderWindow : Window, RenderTarget
 	 */
 	@property
 	{
-		const(View) view(const(View) newView)
+		override View view(View newView)
 		{
-			sfRenderWindow_setView(sfPtr, newView.sfPtr);
-			m_currentView = new View(sfRenderWindow_getView(sfPtr));
-			return m_currentView;
+			sfRenderWindow_setView(sfPtr, newView.center.x, newView.center.y, newView.size.x, newView.size.y, newView.rotation,
+									newView.viewport.left, newView.viewport.top, newView.viewport.width, newView.viewport.height);
+			return newView;
 		}
-		const(View) view() const
+		override View view() const
 		{
-			return m_currentView;
+			View currentView;
+
+			Vector2f currentCenter, currentSize;
+			float currentRotation;
+			FloatRect currentViewport;
+
+			sfRenderWindow_getView(sfPtr, &currentCenter.x, &currentCenter.y, &currentSize.x, &currentSize.y, &currentRotation,
+									&currentViewport.left, &currentViewport.top, &currentViewport.width, &currentViewport.height);
+
+			currentView.center = currentCenter;
+			currentView.size = currentSize;
+			currentView.rotation = currentRotation;
+			currentView.viewport = currentViewport;
+
+			return currentView;
 		}
 	}
 
@@ -162,9 +174,23 @@ class RenderWindow : Window, RenderTarget
 	 *
 	 * Returns: The default view of the render target.
 	 */
-	const(View) getDefaultView() const // note: if refactored, change documentation of view property above
+	View getDefaultView() const // note: if refactored, change documentation of view property above
 	{
-		return m_defaultView;
+		View currentView;
+
+		Vector2f currentCenter, currentSize;
+		float currentRotation;
+		FloatRect currentViewport;
+
+		sfRenderWindow_getDefaultView(sfPtr, &currentCenter.x, &currentCenter.y, &currentSize.x, &currentSize.y, &currentRotation,
+								&currentViewport.left, &currentViewport.top, &currentViewport.width, &currentViewport.height);
+
+		currentView.center = currentCenter;
+		currentView.size = currentSize;
+		currentView.rotation = currentRotation;
+		currentView.viewport = currentViewport;
+
+		return currentView;
 	}
 
 	/**
@@ -206,25 +232,6 @@ class RenderWindow : Window, RenderTarget
 	override WindowHandle getSystemHandle() const
 	{
 		return sfRenderWindow_getSystemHandle(sfPtr);
-	}
-
-	/**
-	 * Get the viewport of a view, applied to this render target.
-	 *
-	 * The viewport is defined in the view as a ratio, this function simply applies this ratio to the current dimensions of the render target to calculate the pixels rectangle that the viewport actually covers in the target.
-	 *
-	 * Params:
-	 * 		view	= The view for which we want to compute the viewport
-	 *
-	 * Returns: Viewport rectangle, expressed in pixels
-	 */
-	IntRect getViewport(const(View) view) const
-	{
-		IntRect temp;
-
-		sfRenderWindow_getViewport(sfPtr, view.sfPtr, &temp.left, &temp.top, &temp.width, &temp.height);
-
-		return temp;
 	}
 
 	/**
@@ -425,12 +432,6 @@ class RenderWindow : Window, RenderTarget
 		sfRenderWindow_createFromSettings(sfPtr, mode.width, mode.height, mode.bitsPerPixel, convertedTitle.ptr, convertedTitle.length, style, settings.depthBits, settings.stencilBits, settings.antialiasingLevel, settings.majorVersion, settings.minorVersion);
 		err.write(dsfml.system.string.toString(sfErr_getOutput()));
 
-		//get view
-		m_currentView = new View(sfRenderWindow_getView(sfPtr));
-
-		//get default view
-		m_defaultView = new View(sfRenderWindow_getDefaultView(sfPtr));
-
 	}
 	///Create (or recreate) the window.
 	///
@@ -445,12 +446,6 @@ class RenderWindow : Window, RenderTarget
 		sfRenderWindow_createFromSettings(sfPtr, mode.width, mode.height, mode.bitsPerPixel, convertedTitle.ptr, convertedTitle.length, style, settings.depthBits, settings.stencilBits, settings.antialiasingLevel, settings.majorVersion, settings.minorVersion);
 		err.write(dsfml.system.string.toString(sfErr_getOutput()));
 
-		//get view
-		m_currentView = new View(sfRenderWindow_getView(sfPtr));
-
-		//get default view
-		m_defaultView = new View(sfRenderWindow_getDefaultView(sfPtr));
-
 	}
 	///Create (or recreate) the window.
 	///
@@ -462,13 +457,6 @@ class RenderWindow : Window, RenderTarget
 		import dsfml.system.string;
 		sfRenderWindow_createFromSettings(sfPtr, mode.width, mode.height, mode.bitsPerPixel, title.ptr, title.length, style, settings.depthBits, settings.stencilBits, settings.antialiasingLevel, settings.majorVersion, settings.minorVersion);
 		err.write(dsfml.system.string.toString(sfErr_getOutput()));
-
-		//get view
-		m_currentView = new View(sfRenderWindow_getView(sfPtr));
-
-		//get default view
-		m_defaultView = new View(sfRenderWindow_getDefaultView(sfPtr));
-
 	}
 
 	///Create (or recreate) the window from an existing control.
@@ -481,11 +469,6 @@ class RenderWindow : Window, RenderTarget
 		import dsfml.system.string;
 		sfRenderWindow_createFromHandle(sfPtr, handle, settings.depthBits,settings.stencilBits, settings.antialiasingLevel, settings.majorVersion, settings.minorVersion);
 		err.write(dsfml.system.string.toString(sfErr_getOutput()));
-		//get view
-		m_currentView = new View(sfRenderWindow_getView(sfPtr));
-
-		//get default view
-		m_defaultView = new View(sfRenderWindow_getDefaultView(sfPtr));
 	}
 
 	/**
@@ -537,94 +520,6 @@ class RenderWindow : Window, RenderTarget
 	override bool isOpen()
 	{
 		return (sfRenderWindow_isOpen(sfPtr));
-	}
-
-	/**
-	 * Convert a point fom target coordinates to world coordinates, using the current view.
-	 *
-	 * This function is an overload of the mapPixelToCoords function that implicitely uses the current view.
-	 *
-	 * Params:
-	 * 		point	= Pixel to convert
-	 *
-	 * Returns: The converted point, in "world" coordinates.
-	 */
-	Vector2f mapPixelToCoords(Vector2i point) const
-	{
-		Vector2f temp;
-
-		sfRenderWindow_mapPixelToCoords(sfPtr,point.x, point.y, &temp.x, &temp.y,null);
-
-		return temp;
-	}
-
-	/**
-	 * Convert a point from target coordinates to world coordinates.
-	 *
-	 * This function finds the 2D position that matches the given pixel of the render-target. In other words, it does the inverse of what the graphics card does, to find the initial position of a rendered pixel.
-	 *
-	 * Initially, both coordinate systems (world units and target pixels) match perfectly. But if you define a custom view or resize your render-target, this assertion is not true anymore, ie. a point located at (10, 50) in your render-target may map to the point (150, 75) in your 2D world – if the view is translated by (140, 25).
-	 *
-	 * For render-windows, this function is typically used to find which point (or object) is located below the mouse cursor.
-	 *
-	 * This version uses a custom view for calculations, see the other overload of the function if you want to use the current view of the render-target.
-	 *
-	 * Params:
-	 * 		point	= Pixel to convert
-	 * 		view	= The view to use for converting the point
-	 *
-	 * Returns: The converted point, in "world" coordinates.
-	 */
-	Vector2f mapPixelToCoords(Vector2i point, const(View) view) const
-	{
-		Vector2f temp;
-
-		sfRenderWindow_mapPixelToCoords(sfPtr,point.x, point.y, &temp.x, &temp.y,view.sfPtr);
-
-		return temp;
-	}
-
-	/**
-	 * Convert a point from target coordinates to world coordinates, using the current view.
-	 *
-	 * This function is an overload of the mapPixelToCoords function that implicitely uses the current view.
-	 *
-	 * Params:
-	 * 		point	= Point to convert
-	 *
-	 * The converted point, in "world" coordinates
-	 */
-	Vector2i mapCoordsToPixel(Vector2f point) const
-	{
-		Vector2i temp;
-
-		sfRenderWindow_mapCoordsToPixel(sfPtr,point.x, point.y, &temp.x, &temp.y,null);
-
-		return temp;
-	}
-
-	/**
-	 * Convert a point from world coordinates to target coordinates.
-	 *
-	 * This function finds the pixel of the render-target that matches the given 2D point. In other words, it goes through the same process as the graphics card, to compute the final position of a rendered point.
-	 *
-	 * Initially, both coordinate systems (world units and target pixels) match perfectly. But if you define a custom view or resize your render-target, this assertion is not true anymore, ie. a point located at (150, 75) in your 2D world may map to the pixel (10, 50) of your render-target – if the view is translated by (140, 25).
-	 *
-	 * This version uses a custom view for calculations, see the other overload of the function if you want to use the current view of the render-target.
-	 *
-	 * Params:
-	 * 		point	= Point to convert
-	 * 		view	= The view to use for converting the point
-	 *
-	 * Returns: The converted point, in target coordinates (pixels)
-	 */
-	Vector2i mapCoordsToPixel(Vector2f point, const(View) view) const
-	{
-		Vector2i temp;
-
-		sfRenderWindow_mapCoordsToPixel(sfPtr,point.x, point.y, &temp.x, &temp.y,view.sfPtr);
-
-		return temp;
 	}
 
 	/**
@@ -904,26 +799,19 @@ WindowHandle sfRenderWindow_getSystemHandle(const sfRenderWindow* renderWindow);
 void sfRenderWindow_clear(sfRenderWindow* renderWindow, ubyte r, ubyte g, ubyte b, ubyte a);
 
 //Change the current active view of a render window
-void sfRenderWindow_setView(sfRenderWindow* renderWindow, const sfView* view);
+void sfRenderWindow_setView(sfRenderWindow* renderWindow, float centerX, float centerY, float sizeX,
+												float sizeY, float rotation, float viewportLeft, float viewportTop, float viewportWidth,
+												float viewportHeight);
 
 //Get the current active view of a render window
-sfView* sfRenderWindow_getView(const sfRenderWindow* renderWindow);
+void sfRenderWindow_getView(const sfRenderWindow* renderWindow, float* centerX, float* centerY, float* sizeX,
+												float* sizeY, float* rotation, float* viewportLeft, float* viewportTop, float* viewportWidth,
+												float* viewportHeight);
 
 //Get the default view of a render window
-sfView* sfRenderWindow_getDefaultView(const sfRenderWindow* renderWindow);
-
-//Get the viewport of a view applied to this target
-void sfRenderWindow_getViewport(const sfRenderWindow* renderWindow, const sfView* view, int* left, int* top, int* width, int* height);
-
-//Convert a point from window coordinates to world coordinates
-void sfRenderWindow_mapPixelToCoords(const sfRenderWindow* renderWindow, int xIn, int yIn, float* xOut, float* yOut, const sfView* targetView);
-
-//Convert a point from world coordinates to window coordinates
-void sfRenderWindow_mapCoordsToPixel(const sfRenderWindow* renderWindow, float xIn, float yIn, int* xOut, int* yOut, const sfView* targetView);
-
-//Draw a drawable object to the render-target
-//void sfRenderWindow_drawText(sfRenderWindow* renderWindow, const sfText* object, int blendMode,const float* transform, const sfTexture* texture, const sfShader* shader);
-
+void sfRenderWindow_getDefaultView(const sfRenderWindow* renderWindow, float* centerX, float* centerY, float* sizeX,
+												float* sizeY, float* rotation, float* viewportLeft, float* viewportTop, float* viewportWidth,
+												float* viewportHeight);
 
 //Draw primitives defined by an array of vertices to a render window
 void sfRenderWindow_drawPrimitives(sfRenderWindow* renderWindow,const (void)* vertices, uint vertexCount, int type, int colorSrcFactor, int colorDstFactor, int colorEquation,

--- a/src/dsfml/graphics/shader.d
+++ b/src/dsfml/graphics/shader.d
@@ -438,14 +438,14 @@ class Shader
 	void setParameter(const(char)[] name, const(Texture) texture)
 	{
 		import dsfml.system.string;
-		sfShader_setTextureParameter(sfPtr, name.ptr, name.length, texture.sfPtr);
+		sfShader_setTextureParameter(sfPtr, name.ptr, name.length, texture?texture.sfPtr:null);
 		err.write(dsfml.system.string.toString(sfErr_getOutput()));
 	}
 	///ditto
 	void opIndexAssign(const(Texture) texture, const(char)[] name)
 	{
 		import dsfml.system.string;
-		sfShader_setTextureParameter(sfPtr, name.ptr, name.length, texture.sfPtr);
+		sfShader_setTextureParameter(sfPtr, name.ptr, name.length, texture?texture.sfPtr:null);
 		err.write(dsfml.system.string.toString(sfErr_getOutput()));
 	}
 

--- a/src/dsfml/graphics/view.d
+++ b/src/dsfml/graphics/view.d
@@ -21,67 +21,54 @@ module dsfml.graphics.view;
 
 import dsfml.graphics.rect;
 import dsfml.system.vector2;
+import dsfml.graphics.transform;
 
 /++
  + 2D camera that defines what region is shown on screen
- + 
+ +
  + View defines a camera in the 2D scene.
- + 
+ +
  + This is a very powerful concept: you can scroll, rotate or zoom the entire scene without altering the way that your drawable objects are drawn.
- + 
+ +
  + A view is composed of a source rectangle, which defines what part of the 2D scene is shown, and a target viewport, which defines where the contents of the source rectangle will be displayed on the render target (window or texture).
- + 
+ +
  + The viewport allows to map the scene to a custom part of the render target, and can be used for split-screen or for displaying a minimap, for example. If the source rectangle has not the same size as the viewport, its contents will be stretched to fit in.
- + 
+ +
  + To apply a view, you have to assign it to the render target. Then, every objects drawn in this render target will be affected by the view until you use another view.
- + 
+ +
  + Authors: Laurent Gomila, Jeremy DeHaan
  + See_Also: http://www.sfml-dev.org/documentation/2.0/classsf_1_1View.php#details
  +/
 
-class View
+struct View
 {
-	package sfView* sfPtr;
-	
-	this()
+	this (FloatRect rectangle)
 	{
-		// Constructor code
-		sfPtr = sfView_create();
+		reset (rectangle);
 	}
 
-	this(FloatRect rectangle)
+	this (Vector2f center, Vector2f size)
 	{
-		
-		sfPtr = sfView_createFromRect(rectangle.left,rectangle.top, rectangle.width, rectangle.height);
+		m_center = center;
+		m_size = size;
 	}
-	
-	package this(sfView* sfview)
-	{
-		sfPtr = sfView_copy(sfview);
-	}
-
-	~this()
-	{
-		import dsfml.system.config;
-		mixin(destructorOutput);
-		sfView_destroy(sfPtr);
-	}
-
 	/// The center of the view.
 	@property
 	{
 		Vector2f center(Vector2f newCenter)
 		{
-			sfView_setCenter(sfPtr, newCenter.x, newCenter.y);
+			m_center = newCenter;
+
+			m_transformUpdated = false;
+			m_invTransformUpdated = false;
+
 			return newCenter;
 		}
-		
+
 		Vector2f center() const
 		{
-			Vector2f temp;
-			sfView_getCenter(sfPtr, &temp.x, &temp.y);
-			return temp;
-		}	
+			return m_center;
+		}
 	}
 
 	/// The orientation of the view, in degrees. The default rotation is 0 degrees.
@@ -89,13 +76,19 @@ class View
 	{
 		float rotation(float newRotation)
 		{
-			sfView_setRotation(sfPtr, newRotation);
+			m_rotation = newRotation % 360.0;
+			if (m_rotation <0)
+				m_rotation += 360.0;
+
+			m_transformUpdated = false;
+			m_invTransformUpdated = false;
+
 			return newRotation;
 		}
 		float rotation() const
 		{
-			return sfView_getRotation(sfPtr);
-			
+			return m_rotation;
+
 		}
 	}
 
@@ -104,89 +97,167 @@ class View
 	{
 		Vector2f size(Vector2f newSize)
 		{
-			sfView_setSize(sfPtr, newSize.x, newSize.y);
+			m_size = newSize;
+			m_transformUpdated = false;
+			m_invTransformUpdated = false;
 			return newSize;
 		}
-		
+
 		Vector2f size() const
 		{
-			Vector2f temp;
-			sfView_getSize(sfPtr, &temp.x, &temp.y);
-			return temp;
+			return m_size;
 		}
 	}
 
 	/**
 	 * The target viewpoirt.
-	 * 
+	 *
 	 * The viewport is the rectangle into which the contents of the view are displayed, expressed as a factor (between 0 and 1) of the size of the RenderTarget to which the view is applied. For example, a view which takes the left side of the target would be defined with View.setViewport(FloatRect(0, 0, 0.5, 1)). By default, a view has a viewport which covers the entire target.
 	 */
 	@property
 	{
 		FloatRect viewport(FloatRect newTarget)
 		{
-			sfView_setViewport(sfPtr, newTarget.left, newTarget.top, newTarget.width, newTarget.height);
+			m_viewport = newTarget;
+
 			return newTarget;
 		}
 		FloatRect viewport() const
 		{
-			FloatRect temp;
-			sfView_getViewport(sfPtr, &temp.left, &temp.top, &temp.width, &temp.height);
-			return temp;
+			return m_viewport;
 		}
 	}
 
 	/**
-	 * Performs a deep copy of the view.
-	 * 
-	 * Returns: Duplicated view.
-	 */
-	@property
-	View dup() const
-	{
-		return new View(sfView_copy(sfPtr));
-	}
-
-	/**
 	 * Move the view relatively to its current position.
-	 * 
+	 *
 	 * Params:
 	 * 		offset	= Move offset
 	 */
 	void move(Vector2f offset)
 	{
-		sfView_move(sfPtr, offset.x, offset.y);
+		center = m_center + offset;
 	}
 
 	/**
 	 * Reset the view to the given rectangle.
-	 * 
+	 *
 	 * Note that this function resets the rotation angle to 0.
-	 * 
+	 *
 	 * Params:
 	 * 		rectangle	= Rectangle defining the zone to display.
 	 */
 	void reset(FloatRect rectangle)
 	{
-		sfView_reset(sfPtr, rectangle.left,rectangle.top, rectangle.width, rectangle.height);
+		m_center.x = rectangle.left + rectangle.width / 2.0;
+		m_center.y = rectangle.top + rectangle.height / 2.0;
+		m_size.x = rectangle.width;
+		m_size.y = rectangle.height;
+		m_rotation = 0;
+
+		m_transformUpdated = false;
+		m_invTransformUpdated = false;
 	}
 
 	/**
 	 * Resize the view rectangle relatively to its current size.
-	 * 
+	 *
 	 * Resizing the view simulates a zoom, as the zone displayed on screen grows or shrinks. factor is a multiplier:
 	 * - 1 keeps the size unchanged.
 	 * - > 1 makes the view bigger (objects appear smaller).
 	 * - < 1 makes the view smaller (objects appear bigger).
-	 * 
+	 *
 	 * Params:
 	 * 		factor	= Zoom factor to apply.
 	 */
 	void zoom(float factor)
 	{
-		sfView_zoom(sfPtr, factor);
+		size = m_size * factor;
+	}
+
+	/**
+	  Get the projection transform of the view.
+
+	  This function is meant for internal use only.
+
+	  Returns
+	      Projection transform defining the view
+
+	  See also
+	      getInverseTransform
+	*/
+
+	Transform getTransform()
+	{
+		import std.math;
+	    // Recompute the matrix if needed
+	    if (!m_transformUpdated)
+	    {
+	        // Rotation components
+	        float angle  = m_rotation * 3.141592654f / 180.f;
+	        float cosine = cos(angle);
+	        float sine   = sin(angle);
+	        float tx     = -m_center.x * cosine - m_center.y * sine + m_center.x;
+	        float ty     =  m_center.x * sine - m_center.y * cosine + m_center.y;
+
+	        // Projection components
+	        float a =  2.f / m_size.x;
+	        float b = -2.f / m_size.y;
+	        float c = -a * m_center.x;
+	        float d = -b * m_center.y;
+
+	        // Rebuild the projection matrix
+	        m_transform = Transform( a * cosine, a * sine,   a * tx + c,
+	                                -b * sine,   b * cosine, b * ty + d,
+	                                 0.f,        0.f,        1.f);
+	        m_transformUpdated = true;
+	    }
+
+	    return m_transform;
+	}
+
+
+
+	/**
+	  Get the inverse projection transform of the view.
+
+	  This function is meant for internal use only.
+
+	  Returns
+	      Inverse of the projection transform defining the view
+
+	  See also
+	      getTransform
+	*/
+
+	Transform getInverseTransform()
+	{
+	    // Recompute the matrix if needed
+	    if (!m_invTransformUpdated)
+	    {
+	        m_inverseTransform = getTransform().getInverse();
+	        m_invTransformUpdated = true;
+	    }
+
+	    return m_inverseTransform;
+	}
+
+	package
+	{
+		Vector2f m_center = Vector2f(500, 500);
+		Vector2f m_size = Vector2f(1000, 1000);
+		float m_rotation = 0;
+		FloatRect m_viewport = FloatRect(0, 0, 1, 1);
+	}
+	private
+	{
+		bool m_transformUpdated;
+		bool m_invTransformUpdated;
+		Transform m_transform;
+		Transform m_invTransform;
 	}
 }
+
 
 unittest
 {
@@ -205,7 +276,7 @@ unittest
 		view.viewport = FloatRect(0,0,1,1);
 
 		auto renderTexture = new RenderTexture();
-		
+
 		renderTexture.create(1000,1000);
 
 		renderTexture.clear();
@@ -227,67 +298,3 @@ unittest
 }
 
 
-package extern(C) struct sfView;
-
-private extern(C):
-
-//Create a default view
-sfView* sfView_create();
-
-//Construct a view from a rectangle
-sfView* sfView_createFromRect(float left, float top, float width, float height);
-
-
-//Copy an existing view
-sfView* sfView_copy(const sfView* view);
-
-
-//Destroy an existing view
-void sfView_destroy(sfView* view);
-
-
-//Set the center of a view
-void sfView_setCenter(sfView* view, float centerX, float centerY);
-
-
-//Set the size of a view
-void sfView_setSize(sfView* view, float sizeX, float sizeY);
-
-
-//Set the orientation of a view
-void sfView_setRotation(sfView* view, float angle);
-
-
-//Set the target viewport of a view
-void sfView_setViewport(sfView* view, float left, float top, float width, float height);
-
-
-//Reset a view to the given rectangle
-void sfView_reset(sfView* view, float left, float top, float width, float height);
-
-
-//Get the center of a view
-void sfView_getCenter(const sfView* view, float* x, float* y);
-
-
-//Get the size of a view
-void sfView_getSize(const sfView* view, float* x, float* y);
-
-
-//Get the current orientation of a view
-float sfView_getRotation(const sfView* view);
-
-
-//Get the target viewport rectangle of a view
-void sfView_getViewport(const sfView* view, float* left, float* top, float* width, float* height);
-
-//Move a view relatively to its current position
-void sfView_move(sfView* view, float offsetX, float offsetY);
-
-
-//Rotate a view relatively to its current orientation
-void sfView_rotate(sfView* view, float angle);
-
-
-//Resize a view rectangle relatively to its current size
-void sfView_zoom(sfView* view, float factor);

--- a/src/dsfml/window/contextsettings.d
+++ b/src/dsfml/window/contextsettings.d
@@ -25,7 +25,7 @@ module dsfml.window.contextsettings;
  *
  *ContextSettings allows to define several advanced settings of the OpenGL context attached to a window.
  *
- *All these settings have no impact on the regular SFML rendering (graphics module) – except the 
+ *All these settings have no impact on the regular SFML rendering (graphics module) – except the
  *anti-aliasing level, so you may need to use this structure only if you're using SFML as a windowing system for custom OpenGL rendering.
  *
  *The depthBits and stencilBits members define the number of bits per pixel requested for the (respectively) depth and stencil buffers.
@@ -33,12 +33,12 @@ module dsfml.window.contextsettings;
  *antialiasingLevel represents the requested number of multisampling levels for anti-aliasing.
  *
  *majorVersion and minorVersion define the version of the OpenGL context that you want. Only versions
- *greater or equal to 3.0 are relevant; versions lesser than 3.0 are all handled the same way (i.e. you 
+ *greater or equal to 3.0 are relevant; versions lesser than 3.0 are all handled the same way (i.e. you
  *(can use any version < 3.0 if you don't want an OpenGL 3 context).
  *
- *Please note that these values are only a hint. No failure will be reported if one or more of these 
- *values are not supported by the system; instead, SFML will try to find the closest valid match. 
- *You can then retrieve the settings that the window actually used to create its context, with Window.getSettings(). 
+ *Please note that these values are only a hint. No failure will be reported if one or more of these
+ *values are not supported by the system; instead, SFML will try to find the closest valid match.
+ *You can then retrieve the settings that the window actually used to create its context, with Window.getSettings().
  */
 struct ContextSettings
 {
@@ -52,7 +52,5 @@ struct ContextSettings
 	uint majorVersion = 2;
 	///Minor number of the context version to create.
 	uint minorVersion = 0;
-	
-	static const(ContextSettings) Default;
 }
 //unittest?

--- a/src/dsfml/window/window.d
+++ b/src/dsfml/window/window.d
@@ -92,7 +92,7 @@ class Window
 	///  	title = Title of the window.
 	///   	style = Window style.
 	///    	settings = Additional settings for the underlying OpenGL context.
-	this(T)(VideoMode mode, immutable(T)[] title, Style style = Style.DefaultStyle, ref const(ContextSettings) settings = ContextSettings.Default)
+	this(T)(VideoMode mode, immutable(T)[] title, Style style = Style.DefaultStyle, ContextSettings settings = ContextSettings.init)
 		if (is(T == dchar)||is(T == wchar)||is(T == char))
 	{
 		this();
@@ -108,7 +108,7 @@ class Window
 	///Params:
     ///		handle = Platform-specific handle of the control.
     ///		settings = Additional settings for the underlying OpenGL context.
-	this(WindowHandle handle, ref const(ContextSettings) settings = ContextSettings.Default)
+	this(WindowHandle handle, ContextSettings settings = ContextSettings.init)
 	{
 		this();
 		create(handle, settings);
@@ -351,7 +351,7 @@ class Window
 	///If the window was already created, it closes it first. If style contains Style::Fullscreen, then mode must be a valid video mode.
 	///
 	///The fourth parameter is an optional structure specifying advanced OpenGL context settings such as antialiasing, depth-buffer bits, etc.
-	void create(VideoMode mode, const(char)[] title, Style style = Style.DefaultStyle, ref const(ContextSettings) settings = ContextSettings.Default)
+	void create(VideoMode mode, const(char)[] title, Style style = Style.DefaultStyle, ContextSettings settings = ContextSettings.init)
 	{
 		import dsfml.system.string;
 
@@ -364,7 +364,7 @@ class Window
 	///If the window was already created, it closes it first. If style contains Style::Fullscreen, then mode must be a valid video mode.
 	///
 	///The fourth parameter is an optional structure specifying advanced OpenGL context settings such as antialiasing, depth-buffer bits, etc.
-	void create(VideoMode mode, const(wchar)[] title, Style style = Style.DefaultStyle, ref const(ContextSettings) settings = ContextSettings.Default)
+	void create(VideoMode mode, const(wchar)[] title, Style style = Style.DefaultStyle, ContextSettings settings = ContextSettings.init)
 	{
 		import dsfml.system.string;
 		auto convertedTitle = stringConvert!(wchar,dchar)(title);
@@ -376,7 +376,7 @@ class Window
 	///If the window was already created, it closes it first. If style contains Style::Fullscreen, then mode must be a valid video mode.
 	///
 	///The fourth parameter is an optional structure specifying advanced OpenGL context settings such as antialiasing, depth-buffer bits, etc.
-	void create(VideoMode mode, const(dchar)[] title, Style style = Style.DefaultStyle, ref const(ContextSettings) settings = ContextSettings.Default)
+	void create(VideoMode mode, const(dchar)[] title, Style style = Style.DefaultStyle, ContextSettings settings = ContextSettings.init)
 	{
 		import dsfml.system.string;
 		sfWindow_createFromSettings(sfPtr, mode.width, mode.height, mode.bitsPerPixel, title.ptr, title.length, style, settings.depthBits, settings.stencilBits, settings.antialiasingLevel, settings.majorVersion, settings.minorVersion);
@@ -388,7 +388,7 @@ class Window
 	///Use this function if you want to create an OpenGL rendering area into an already existing control. If the window was already created, it closes it first.
 	///
 	///The second parameter is an optional structure specifying advanced OpenGL context settings such as antialiasing, depth-buffer bits, etc.
-	void create(WindowHandle handle, ref const(ContextSettings) settings = ContextSettings.Default)
+	void create(WindowHandle handle, ContextSettings settings = ContextSettings.init)
 	{
 		import dsfml.system.string;
 		sfWindow_createFromHandle(sfPtr, handle, settings.depthBits,settings.stencilBits, settings.antialiasingLevel, settings.majorVersion, settings.minorVersion);


### PR DESCRIPTION
This is the D-side of the PR to convert View to a struct. At the moment the pull needs #230, but that will be trivial to change if we decide to take a different approach to that.

This is also doing most of the computation on the D-side, through final methods on the RenderTarget interface, though that can be switched to UFCS if we need to allow overridability. Only RenderTarget.setView and RenderTarget.getView need C++ wrapping.
