### PR TITLE
Updated IpAddress

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,9 @@
-Changes 2.1->2.4
-------------------
+DSFML 2.4
+=========
+
+General
+=======
+
 Added Supported Compilers:
 - DMD 2.074.1, 2.075.0
 - LDC 1.2.0, 1.3.0
@@ -9,3 +13,27 @@ Dropped Supported Compilers:
 - LDC 1.0.0 (Not correctly configured on Travic CI for OSX)
 - LDC 0.17.x (New versions of this compiler are not built for Windows)
 - LDC 0.16.1 (Droped support for DMD version 2.067)
+
+Network
+=======
+
+IpAddress
+---------
+Updated IpAddress to match the current SFML IpAddress structure, and changed all
+IpAddress usage to use the structure directly instead of relying on internal
+helper functions.
+
+Updated the IpAddress from bytes and from uint constructors to run at compile
+time.
+
+Added the IpAddress.Any constant, which represents any Ip Address.
+
+TcpListener
+----------
+The listen function can now accept a specific IpAddress to listen to, and
+defaults to IpAddress.Any.
+
+UdpSocket
+----------
+The bind function can now accept a specific IpAddress to be bound to, and
+defaults to IpAddress.Any.

--- a/include/DSFMLC/Network/Export.h
+++ b/include/DSFMLC/Network/Export.h
@@ -37,7 +37,7 @@ All Libraries used by SFML
 //If we define DSFML_NETWORK_EXPORTS
 #if defined(DSFML_NETWORK_EXPORTS)
 	//We need to make sure the SFML_NETWORK_EXPORTS is defined as well
-	//#define SFML_NETWORK_EXPORTS 
+	//#define SFML_NETWORK_EXPORTS
 #endif
 
 //Then we define out D export. Will work for shared and static builds (since for static SFML_API_EXPORT is just empty)

--- a/include/DSFMLC/Network/Ftp.h
+++ b/include/DSFMLC/Network/Ftp.h
@@ -106,7 +106,7 @@ DSFML_NETWORK_API void sfFtp_destroy(sfFtp* ftp);
 
 
 //Connect to the specified FTP server
-DSFML_NETWORK_API sfFtpResponse* sfFtp_connect(sfFtp* ftp, const char* serverIP, size_t serverIPLength, DUshort port, DLong timeout);
+DSFML_NETWORK_API sfFtpResponse* sfFtp_connect(sfFtp* ftp, sf::IpAddress* serverIP, DUshort port, DLong timeout);
 
 
 //Log in using an anonymous account

--- a/include/DSFMLC/Network/IpAddress.h
+++ b/include/DSFMLC/Network/IpAddress.h
@@ -33,35 +33,20 @@ All Libraries used by SFML
 
 // Headers
 #include <DSFMLC/Network/Export.h>
+#include <SFML/Network/IpAddress.hpp>
 #include <stddef.h>
 
 
-//Note: These functions rely on passing an existing array for the ipAddress.
-//It will not allocate data into a null pointer for functions that return a new IP Address
-
-
-//Create an address from a string
-DSFML_NETWORK_API void sfIpAddress_fromString(const char* address, size_t addressLength, char* ipAddress);
-
-
-//Create an address from 4 bytes
-DSFML_NETWORK_API void sfIpAddress_fromBytes(DUbyte byte0, DUbyte byte1, DUbyte byte2, DUbyte byte3, char* ipAddress);
-
-
-//Construct an address from a 32-bits integer
-DSFML_NETWORK_API void sfIpAddress_fromInteger(DUint address, char* ipAddress);
-
-
-//Get an integer representation of the address
-DSFML_NETWORK_API DUint sfIpAddress_toInteger(const char* ipAddress, size_t length);
+//Get the host integer representation from a string
+DSFML_NETWORK_API DUint sfIpAddress_integerFromString(const char* address, size_t addressLength);
 
 
 //Get the computer's local address
-DSFML_NETWORK_API void sfIpAddress_getLocalAddress(char* ipAddress);
+DSFML_NETWORK_API void sfIpAddress_getLocalAddress(sf::IpAddress* ipAddress);
 
 
 //Get the computer's public address
-DSFML_NETWORK_API void sfIpAddress_getPublicAddress(char* ipAddress, DLong timeout);
+DSFML_NETWORK_API void sfIpAddress_getPublicAddress(sf::IpAddress* ipAddress, DLong timeout);
 
 
 #endif // DSFML_IPADDRESS_H

--- a/include/DSFMLC/Network/TcpListener.h
+++ b/include/DSFMLC/Network/TcpListener.h
@@ -34,6 +34,7 @@ All Libraries used by SFML
 // Headers
 #include <DSFMLC/Network/Export.h>
 #include <DSFMLC/Network/Types.h>
+#include <SFML/Network/IpAddress.hpp>
 
 
 
@@ -58,7 +59,7 @@ DSFML_NETWORK_API DUshort sfTcpListener_getLocalPort(const sfTcpListener* listen
 
 
 //Start listening for connections
-DSFML_NETWORK_API DInt sfTcpListener_listen(sfTcpListener* listener, DUshort port);
+DSFML_NETWORK_API DInt sfTcpListener_listen(sfTcpListener* listener, DUshort port, const sf::IpAddress* address);
 
 
 //Accept a new connection

--- a/include/DSFMLC/Network/TcpSocket.h
+++ b/include/DSFMLC/Network/TcpSocket.h
@@ -63,7 +63,7 @@ DSFML_NETWORK_API DUshort sfTcpSocket_getLocalPort(const sfTcpSocket* socket);
 
 
 //Get the address of the connected peer of a TCP socket
-DSFML_NETWORK_API void sfTcpSocket_getRemoteAddress(const sfTcpSocket* socket, char* ipAddress);
+DSFML_NETWORK_API void sfTcpSocket_getRemoteAddress(const sfTcpSocket* socket, sf::IpAddress* ipAddress);
 
 
 //Get the port of the connected peer to which a TCP socket is connected
@@ -71,7 +71,7 @@ DSFML_NETWORK_API DUshort sfTcpSocket_getRemotePort(const sfTcpSocket* socket);
 
 
 //Connect a TCP socket to a remote peer
-DSFML_NETWORK_API DInt sfTcpSocket_connect(sfTcpSocket* socket, const char* hostIP, DUshort port, DLong timeout);
+DSFML_NETWORK_API DInt sfTcpSocket_connect(sfTcpSocket* socket, const sf::IpAddress* ipAddress, DUshort port, DLong timeout);
 
 
 //Disconnect a TCP socket from its remote peer

--- a/include/DSFMLC/Network/UdpSocket.h
+++ b/include/DSFMLC/Network/UdpSocket.h
@@ -63,7 +63,7 @@ DSFML_NETWORK_API DUshort sfUdpSocket_getLocalPort(const sfUdpSocket* socket);
 
 
 //Bind a UDP socket to a specific port
-DSFML_NETWORK_API DInt sfUdpSocket_bind(sfUdpSocket* socket, DUshort port);
+DSFML_NETWORK_API DInt sfUdpSocket_bind(sfUdpSocket* socket, DUshort port, sf::IpAddress* ipAddress);
 
 
 //Unbind a UDP socket from the local port to which it is bound
@@ -71,19 +71,19 @@ DSFML_NETWORK_API void sfUdpSocket_unbind(sfUdpSocket* socket);
 
 
 //Send raw data to a remote peer with a UDP socket
-DSFML_NETWORK_API DInt sfUdpSocket_send(sfUdpSocket* socket, const void* data, size_t size, const char* ipAddress, DUshort port);
+DSFML_NETWORK_API DInt sfUdpSocket_send(sfUdpSocket* socket, const void* data, size_t size, sf::IpAddress* receiver, DUshort port);
 
 
 //Receive raw data from a remote peer with a UDP socket
-DSFML_NETWORK_API void* sfUdpSocket_receive(sfUdpSocket* socket, size_t maxSize, size_t* sizeReceived, char* ipAddress, DUshort* port, DInt* status);
+DSFML_NETWORK_API void* sfUdpSocket_receive(sfUdpSocket* socket, size_t maxSize, size_t* sizeReceived, sf::IpAddress* sender, DUshort* port, DInt* status);
 
 
 //Send a formatted packet of data to a remote peer with a UDP socket
-DSFML_NETWORK_API DInt sfUdpSocket_sendPacket(sfUdpSocket* socket, sfPacket* packet, const char* ipAddress, DUshort port);
+DSFML_NETWORK_API DInt sfUdpSocket_sendPacket(sfUdpSocket* socket, sfPacket* packet, sf::IpAddress* receiver, DUshort port);
 
 
 //Receive a formatted packet of data from a remote peer with a UDP socket
-DSFML_NETWORK_API DInt sfUdpSocket_receivePacket(sfUdpSocket* socket, sfPacket* packet, char* address, DUshort* port);
+DSFML_NETWORK_API DInt sfUdpSocket_receivePacket(sfUdpSocket* socket, sfPacket* packet, sf::IpAddress* sender, DUshort* port);
 
 
 #endif // SFML_UDPSOCKET_H

--- a/src/DSFMLC/Network/Ftp.cpp
+++ b/src/DSFMLC/Network/Ftp.cpp
@@ -128,11 +128,9 @@ void sfFtp_destroy(sfFtp* ftp)
 }
 
 
-sfFtpResponse* sfFtp_connect(sfFtp* ftp, const char* serverIP, size_t length, DUshort port, DLong timeout)
+sfFtpResponse* sfFtp_connect(sfFtp* ftp, sf::IpAddress* serverIP, DUshort port, DLong timeout)
 {
-    sf::IpAddress SFMLServer(std::string(serverIP, length));
-
-    return new sfFtpResponse(ftp->This.connect(SFMLServer, port, sf::microseconds(timeout)));
+    return new sfFtpResponse(ftp->This.connect(*serverIP, port, sf::microseconds(timeout)));
 }
 
 

--- a/src/DSFMLC/Network/IpAddress.cpp
+++ b/src/DSFMLC/Network/IpAddress.cpp
@@ -30,58 +30,23 @@ All Libraries used by SFML
 
 // Headers
 #include <DSFMLC/Network/IpAddress.h>
-#include <SFML/Network/IpAddress.hpp>
 #include <string.h>
 
 
-namespace
-{
-    // Helper function for converting a SFML address to an array one
-    void fromSFMLAddress(sf::IpAddress address, char* ipAddress)
-    {
-        strncpy(ipAddress, address.toString().c_str(), 16);
-    }
 
-    // Helper function for converting an array address to a SFML one
-    sf::IpAddress toSFMLAddress(const char* ipAddress, size_t length)
-    {
-        return sf::IpAddress(std::string(ipAddress, length));
-    }
+DUint sfIpAddress_integerFromString(const char* address, size_t addressLength)
+{
+    return sf::IpAddress(std::string(address, addressLength)).toInteger();
 }
 
 
-void sfIpAddress_fromString(const char* address, size_t addressLength, char* ipAddress)
+void sfIpAddress_getLocalAddress(sf::IpAddress* ipAddress)
 {
-    fromSFMLAddress(sf::IpAddress(std::string(address, addressLength)), ipAddress);
+     *ipAddress = sf::IpAddress::getLocalAddress();
 }
 
 
-void sfIpAddress_fromBytes(DUbyte byte0, DUbyte byte1, DUbyte byte2, DUbyte byte3, char* ipAddress)
+void sfIpAddress_getPublicAddress(sf::IpAddress* ipAddress, DLong timeout)
 {
-    fromSFMLAddress(sf::IpAddress(byte0, byte1, byte2, byte3), ipAddress);
-}
-
-
-void sfIpAddress_fromInteger(DUint address, char* ipAddress)
-{
-    fromSFMLAddress(sf::IpAddress(address), ipAddress);
-}
-
-
-DUint sfIpAddress_toInteger(const char* ipAddress, size_t length)
-{
-    return toSFMLAddress(ipAddress, length).toInteger();
-}
-
-
-void sfIpAddress_getLocalAddress(char* ipAddress)
-{
-     fromSFMLAddress(sf::IpAddress::getLocalAddress(),ipAddress);
-}
-
-
-////////////////////////////////////////////////////////////
-void sfIpAddress_getPublicAddress(char* ipAddress, DLong timeout)
-{
-    fromSFMLAddress(sf::IpAddress::getPublicAddress(sf::microseconds(timeout)), ipAddress);
+    *ipAddress = sf::IpAddress::getPublicAddress(sf::microseconds(timeout));
 }

--- a/src/DSFMLC/Network/TcpListener.cpp
+++ b/src/DSFMLC/Network/TcpListener.cpp
@@ -33,7 +33,6 @@ All Libraries used by SFML
 #include <DSFMLC/Network/TcpListener.h>
 #include <DSFMLC/Network/TcpListenerStruct.h>
 #include <DSFMLC/Network/TcpSocketStruct.h>
-#include <SFML/Network/IpAddress.hpp>
 
 
 sfTcpListener* sfTcpListener_create(void)
@@ -67,14 +66,12 @@ DUshort sfTcpListener_getLocalPort(const sfTcpListener* listener)
 }
 
 
-////////////////////////////////////////////////////////////
-DInt sfTcpListener_listen(sfTcpListener* listener,DUshort port)
+DInt sfTcpListener_listen(sfTcpListener* listener,DUshort port, const sf::IpAddress* address)
 {
-    return listener->This.listen(port, sf::IpAddress(0,0,0,0));
+    return listener->This.listen(port, *address);
 }
 
 
-////////////////////////////////////////////////////////////
 DInt sfTcpListener_accept(sfTcpListener* listener, sfTcpSocket* connected)
 {
     sf::Socket::Status status = listener->This.accept(connected->This);

--- a/src/DSFMLC/Network/TcpSocket.cpp
+++ b/src/DSFMLC/Network/TcpSocket.cpp
@@ -81,12 +81,10 @@ DUshort sfTcpSocket_getLocalPort(const sfTcpSocket* socket)
 }
 
 
-void sfTcpSocket_getRemoteAddress(const sfTcpSocket* socket, char* ipAddress)
+void sfTcpSocket_getRemoteAddress(const sfTcpSocket* socket, sf::IpAddress* ipAddress)
 {
 
-    sf::IpAddress address = socket->This.getRemoteAddress();
-    strncpy(ipAddress, address.toString().c_str(), 16);
-
+    *ipAddress = socket->This.getRemoteAddress();
 }
 
 
@@ -96,12 +94,9 @@ DUshort sfTcpSocket_getRemotePort(const sfTcpSocket* socket)
 }
 
 
-DInt sfTcpSocket_connect(sfTcpSocket* socket, const char* hostIP, DUshort port, DLong timeout)
+DInt sfTcpSocket_connect(sfTcpSocket* socket, const sf::IpAddress* ipAddress, DUshort port, DLong timeout)
 {
-    sf::IpAddress address(hostIP);
-
-
-    return socket->This.connect(address, port, sf::microseconds(timeout));
+    return socket->This.connect(*ipAddress, port, sf::microseconds(timeout));
 }
 
 

--- a/src/DSFMLC/Network/UdpSocket.cpp
+++ b/src/DSFMLC/Network/UdpSocket.cpp
@@ -83,9 +83,9 @@ DUshort sfUdpSocket_getLocalPort(const sfUdpSocket* socket)
 
 
 
-DInt sfUdpSocket_bind(sfUdpSocket* socket, DUshort port)
+DInt sfUdpSocket_bind(sfUdpSocket* socket, DUshort port, sf::IpAddress* ipAddress)
 {
-    return static_cast<DInt>(socket->This.bind(port, sf::IpAddress(0,0,0,0)));
+    return static_cast<DInt>(socket->This.bind(port, *ipAddress));
 }
 
 
@@ -95,54 +95,37 @@ void sfUdpSocket_unbind(sfUdpSocket* socket)
 }
 
 
-DInt sfUdpSocket_send(sfUdpSocket* socket, const void* data, size_t size, const char* ipAddress, DUshort port)
+DInt sfUdpSocket_send(sfUdpSocket* socket, const void* data, size_t size, sf::IpAddress* receiver, DUshort port)
 {
-
-    // Convert the address
-    sf::IpAddress receiver(ipAddress);
-
-    return static_cast<DInt>(socket->This.send(data, size, receiver, port));
+    return static_cast<DInt>(socket->This.send(data, size, *receiver, port));
 }
 
 
 
-void* sfUdpSocket_receive(sfUdpSocket* socket, size_t maxSize, size_t* sizeReceived, char* ipAddress, DUshort* port, DInt* status)
+void* sfUdpSocket_receive(sfUdpSocket* socket, size_t maxSize, size_t* sizeReceived, sf::IpAddress* sender, DUshort* port, DInt* status)
 {
-    //D didn't like passing an array to C++ and having it altered here, so we will be creating a temp
-    //way to store the data and pass it up to D. It should work, so I will look into a different/better solution for 2.2.
+    //TODO: use an existing array in the D side, and fill it here (for 2.4)
 
     sfUdpSocket_destroyInternalData();
     receivedData = new char[maxSize];
 
-    // Call SFML internal function
-    sf::IpAddress sender;
-
-    *status = static_cast<DInt>(socket->This.receive(receivedData, maxSize, *sizeReceived, sender, *port));
-    
-    strncpy(ipAddress, sender.toString().c_str(), 16);
+    *status = static_cast<DInt>(socket->This.receive(receivedData, maxSize, *sizeReceived, *sender, *port));
 
     return static_cast<void*>(receivedData);
 }
 
 
 
-DInt sfUdpSocket_sendPacket(sfUdpSocket* socket, sfPacket* packet, const char* ipAddress, DUshort port)
+DInt sfUdpSocket_sendPacket(sfUdpSocket* socket, sfPacket* packet, sf::IpAddress* receiver, DUshort port)
 {
-    // Convert the address
-    sf::IpAddress receiver(ipAddress);
-
-    return static_cast<DInt>(socket->This.send(packet->This, receiver, port));
+    return static_cast<DInt>(socket->This.send(packet->This, *receiver, port));
 }
 
 
 
-DInt sfUdpSocket_receivePacket(sfUdpSocket* socket, sfPacket* packet, char* ipAddress, DUshort* port)
+DInt sfUdpSocket_receivePacket(sfUdpSocket* socket, sfPacket* packet, sf::IpAddress* sender, DUshort* port)
 {
-    sf::IpAddress sender;
-
-    DInt status = static_cast<DInt>(socket->This.receive(packet->This, sender, *port));
-    
-    strncpy(ipAddress, sender.toString().c_str(), 16);
+    DInt status = static_cast<DInt>(socket->This.receive(packet->This, *sender, *port));
 
     return status;
 }

--- a/src/dsfml/network/ftp.d
+++ b/src/dsfml/network/ftp.d
@@ -106,7 +106,7 @@ class Ftp
 	///Returns: Server response to the request.
 	Response connect(IpAddress address, ushort port = 21, Duration timeout = Duration.zero())
 	{
-		return new Response(sfFtp_connect(sfPtr, address.m_address.ptr, address.m_address.length, port, timeout.total!"usecs"));
+		return new Response(sfFtp_connect(sfPtr, &address, port, timeout.total!"usecs"));
 	}
 
 	///Connect to the specified FTP server.
@@ -123,7 +123,7 @@ class Ftp
 	Response connect(const(char)[] address, ushort port = 21, Duration timeout = Duration.zero())
 	{
 		auto iaddress = IpAddress(address);
-		return new Response(sfFtp_connect(sfPtr, iaddress.m_address.ptr, iaddress.m_address.length, port, timeout.total!"usecs"));
+		return new Response(sfFtp_connect(sfPtr, &iaddress, port, timeout.total!"usecs"));
 	}
 
 	///Remove an existing directory.
@@ -585,7 +585,7 @@ void sfFtp_destroy(sfFtp* ftp);
 
 
 ///Connect to the specified FTP server
-sfFtpResponse* sfFtp_connect(sfFtp* ftp, const(char)* serverIP, size_t length, ushort port, long timeout);
+sfFtpResponse* sfFtp_connect(sfFtp* ftp, IpAddress* serverIP, ushort port, long timeout);
 
 
 ///Log in using an anonymous account

--- a/src/dsfml/network/tcplistener.d
+++ b/src/dsfml/network/tcplistener.d
@@ -21,9 +21,9 @@ If you use this software in a product, an acknowledgment in the product document
 module dsfml.network.tcplistener;
 
 
+import dsfml.network.ipaddress;
 import dsfml.network.socket;
 import dsfml.network.tcpsocket;
-
 import dsfml.system.err;
 
 /**
@@ -103,11 +103,11 @@ class TcpListener:Socket
     ///		port = Port to listen for new connections.
     ///
 	///Returns: Status code.
-	Status listen(ushort port)
+	Status listen(ushort port, IpAddress address = IpAddress.Any)
 	{
 		import dsfml.system.string;
 
-		Status toReturn = sfTcpListener_listen(sfPtr, port);
+		Status toReturn = sfTcpListener_listen(sfPtr, port, &address);
 		err.write(dsfml.system.string.toString(sfErr_getOutput()));
 		return toReturn;
 	}
@@ -181,7 +181,7 @@ ushort sfTcpListener_getLocalPort(const(sfTcpListener)* listener);
 
 
 //Start listening for connections
-Socket.Status sfTcpListener_listen(sfTcpListener* listener, ushort port);
+Socket.Status sfTcpListener_listen(sfTcpListener* listener, ushort port, IpAddress* address);
 
 
 //Accept a new connection

--- a/src/dsfml/network/tcpsocket.d
+++ b/src/dsfml/network/tcpsocket.d
@@ -22,9 +22,9 @@ module dsfml.network.tcpsocket;
 
 import core.time;
 
-import dsfml.network.socket;
 import dsfml.network.ipaddress;
 import dsfml.network.packet;
+import dsfml.network.socket;
 
 import dsfml.system.err;
 
@@ -83,7 +83,7 @@ class TcpSocket:Socket
 	{
 		IpAddress temp;
 
-		sfTcpSocket_getRemoteAddress(sfPtr,temp.m_address.ptr);
+		sfTcpSocket_getRemoteAddress(sfPtr,&temp);
 
 		return temp;
 	}
@@ -123,7 +123,7 @@ class TcpSocket:Socket
     ///Returns: Status code.
 	Status connect(IpAddress host, ushort port, Duration timeout = Duration.zero())
 	{
-		return sfTcpSocket_connect(sfPtr, host.m_address.ptr,port, timeout.total!"usecs");
+		return sfTcpSocket_connect(sfPtr, &host, port, timeout.total!"usecs");
 	}
 
 	///Disconnect the socket from its remote peer.
@@ -324,7 +324,7 @@ ushort sfTcpSocket_getLocalPort(const(sfTcpSocket)* socket);
 
 
 //Get the address of the connected peer of a TCP socket
-void sfTcpSocket_getRemoteAddress(const(sfTcpSocket)* socket, char* ipAddress);
+void sfTcpSocket_getRemoteAddress(const(sfTcpSocket)* socket, IpAddress* ipAddress);
 
 
 //Get the port of the connected peer to which a TCP socket is connected
@@ -332,7 +332,7 @@ ushort sfTcpSocket_getRemotePort(const(sfTcpSocket)* socket);
 
 
 //Connect a TCP socket to a remote peer
-Socket.Status sfTcpSocket_connect(sfTcpSocket* socket, const(char)* hostIP, ushort port, long timeout);
+Socket.Status sfTcpSocket_connect(sfTcpSocket* socket, IpAddress* host, ushort port, long timeout);
 
 
 //Disconnect a TCP socket from its remote peer

--- a/src/dsfml/network/udpsocket.d
+++ b/src/dsfml/network/udpsocket.d
@@ -20,8 +20,8 @@ If you use this software in a product, an acknowledgment in the product document
 ///A module containing the UdpSocket Class.
 module dsfml.network.udpsocket;
 
-import dsfml.network.packet;
 import dsfml.network.ipaddress;
+import dsfml.network.packet;
 import dsfml.network.socket;
 
 import dsfml.system.err;
@@ -95,11 +95,11 @@ class UdpSocket:Socket
     ///		port = Port to bind the socket to.
     ///
 	///Returns: Status code.
-	Status bind(ushort port)
+	Status bind(ushort port, IpAddress address = IpAddress.Any)
 	{
 		import dsfml.system.string;
 
-		Status toReturn = sfUdpSocket_bind(sfPtr,port);
+		Status toReturn = sfUdpSocket_bind(sfPtr,port, &address);
 		err.write(dsfml.system.string.toString(sfErr_getOutput()));
 		return toReturn;
 	}
@@ -124,7 +124,7 @@ class UdpSocket:Socket
     ///Returns: Status code.
 	Status send(const(void)[] data, IpAddress address, ushort port)
 	{
-		Status toReturn = sfUdpSocket_send(sfPtr,data.ptr, data.length,address.m_address.ptr,port);
+		Status toReturn = sfUdpSocket_send(sfPtr,data.ptr, data.length,&address,port);
 
 		return toReturn;
 	}
@@ -148,7 +148,7 @@ class UdpSocket:Socket
 		temp.append(packet.onSend());
 
 		//send the data
-		return sfUdpSocket_sendPacket(sfPtr, temp.sfPtr,address.m_address.ptr,port);
+		return sfUdpSocket_sendPacket(sfPtr, temp.sfPtr, &address, port);
 	}
 
 	///Receive raw data from a remote peer.
@@ -158,18 +158,18 @@ class UdpSocket:Socket
 	///
 	///Params:
 	///		data = The array to fill with the received bytes
-    ///		sizeReceived
+    ///		sizeReceived = The number of bytes received
     ///		address = Address of the peer that sent the data
     ///		port = Port of the peer that sent the data
     ///
 	///Returns: Status code.
-	Status receive(void[] data, out size_t sizeReceived,  out IpAddress address, out ushort port)
+	Status receive(void[] data, out size_t sizeReceived, out IpAddress address, out ushort port)
 	{
 		import dsfml.system.string;
 
 		Status status;
 
-		void* temp = sfUdpSocket_receive(sfPtr, data.length, &sizeReceived, address.m_address.ptr, &port, &status);
+		void* temp = sfUdpSocket_receive(sfPtr, data.length, &sizeReceived, &address, &port, &status);
 
 		err.write(dsfml.system.string.toString(sfErr_getOutput()));
 
@@ -194,7 +194,7 @@ class UdpSocket:Socket
 		scope SfPacket temp = new SfPacket();
 
 		//get the sent data
-		Status status =  sfUdpSocket_receivePacket(sfPtr, temp.sfPtr, address.m_address.ptr, &port);
+		Status status =  sfUdpSocket_receivePacket(sfPtr, temp.sfPtr, &address, &port);
 
 		//put data into the packet so that it can process it first if it wants.
 		packet.onRecieve(temp.getData());
@@ -279,21 +279,21 @@ bool sfUdpSocket_isBlocking(const sfUdpSocket* socket);
 ushort sfUdpSocket_getLocalPort(const(sfUdpSocket)* socket);
 
 //Bind a UDP socket to a specific port
-Socket.Status sfUdpSocket_bind(sfUdpSocket* socket, ushort port);
+Socket.Status sfUdpSocket_bind(sfUdpSocket* socket, ushort port, IpAddress* ipAddress);
 
 //Unbind a UDP socket from the local port to which it is bound
 void sfUdpSocket_unbind(sfUdpSocket* socket);
 
 //Send raw data to a remote peer with a UDP socket
-Socket.Status sfUdpSocket_send(sfUdpSocket* socket, const(void)* data, size_t size, const(char)* ipAddress, ushort port);
+Socket.Status sfUdpSocket_send(sfUdpSocket* socket, const(void)* data, size_t size, IpAddress* receiver, ushort port);
 
 //Receive raw data from a remote peer with a UDP socket
-void* sfUdpSocket_receive(sfUdpSocket* socket, size_t maxSize, size_t* sizeReceived, char* ipAddress, ushort* port, Socket.Status* status);
+void* sfUdpSocket_receive(sfUdpSocket* socket, size_t maxSize, size_t* sizeReceived, IpAddress* sender, ushort* port, Socket.Status* status);
 
 //Send a formatted packet of data to a remote peer with a UDP socket
-Socket.Status sfUdpSocket_sendPacket(sfUdpSocket* socket, sfPacket* packet, const(char)* ipAddress, ushort port);
+Socket.Status sfUdpSocket_sendPacket(sfUdpSocket* socket, sfPacket* packet, IpAddress* receiver, ushort port);
 
 //Receive a formatted packet of data from a remote peer with a UDP socket
-Socket.Status sfUdpSocket_receivePacket(sfUdpSocket* socket, sfPacket* packet, char* address, ushort* port);
+Socket.Status sfUdpSocket_receivePacket(sfUdpSocket* socket, sfPacket* packet, IpAddress* sender, ushort* port);
 
 const(char)* sfErr_getOutput();


### PR DESCRIPTION
This updates a lot of things related to the IpAddress class.

From the changelog:

IpAddress
----------
Updated IpAddress to match the current SFML IpAddress structure, and changed all
IpAddress usage to use the structure directly instead of relying on internal
helper functions.

Updated the IpAddress from bytes and from uint constructors to run at compile
time.

Added the IpAddress.Any constant, which represents any Ip Address.

TcpListener
----------
The listen function can now accept a specific IpAddress to listen to, and
defaults to IpAddress.Any.

UdpSocket
----------
The bind function can now accept a specific IpAddress to be bound to, and
defaults to IpAddress.Any.