### PR TITLE
Update copyright dates

### DIFF
--- a/include/DSFMLC/Audio/Err.h
+++ b/include/DSFMLC/Audio/Err.h
@@ -1,37 +1,33 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_ERR_H
 #define DSFML_ERR_H
 
-//Headers
 #include <DSFMLC/Audio/Export.h>
 
 //Redirect sf::err() so that its output can be gotten later

--- a/include/DSFMLC/Audio/Export.h
+++ b/include/DSFMLC/Audio/Export.h
@@ -1,48 +1,35 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_AUDIO_EXPORT_H
 #define DSFML_AUDIO_EXPORT_H
 
-
-//Headers
 #include <DSFMLC/Config.h>
 
-//If we define DSFML_AUDIO_EXPORTS
-#if defined(DSFML_AUDIO_EXPORTS)
-	//We need to make sure the SFML_AUDIO_EXPORTS is defined as well
-	//#define SFML_AUDIO_EXPORTS 
-#endif
-
-//Then we define out D export. Will work for shared and static builds (since for static SFML_API_EXPORT is just empty)
 #define DSFML_AUDIO_API extern "C" SFML_API_EXPORT
-
 
 #endif // DSFML_AUDIO_EXPORT_H

--- a/include/DSFMLC/Audio/InputSoundFile.h
+++ b/include/DSFMLC/Audio/InputSoundFile.h
@@ -1,37 +1,33 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_INPUTSOUNDFILE_H
 #define DSFML_INPUTSOUNDFILE_H
 
-//Headers
 #include <DSFMLC/Audio/Export.h>
 #include <DSFMLC/Audio/Types.h>
 #include <DSFMLC/System/DStream.hpp>
@@ -47,25 +43,31 @@ DSFML_AUDIO_API void sfInputSoundFile_destroy(sfInputSoundFile* file);
 DSFML_AUDIO_API DLong sfInputSoundFile_getSampleCount(const sfInputSoundFile* file);
 
 //Get the channel count of the sound file
-DSFML_AUDIO_API DUint sfInputSoundFile_getChannelCount( const sfInputSoundFile* file);
+DSFML_AUDIO_API DUint sfInputSoundFile_getChannelCount(const sfInputSoundFile* file);
 
 //Get the sample rate of the sound file
 DSFML_AUDIO_API DUint sfInputSoundFile_getSampleRate(const sfInputSoundFile* file);
 
 //Open a sound file for reading
-DSFML_AUDIO_API DBool sfInputSoundFile_openFromFile(sfInputSoundFile* file, const char* filename, size_t length);
+DSFML_AUDIO_API DBool sfInputSoundFile_openFromFile(sfInputSoundFile* file,
+                                                    const char* filename,
+                                                    size_t length);
 
 //Open a sound file in memory for reading
-DSFML_AUDIO_API DBool sfInputSoundFile_openFromMemory(sfInputSoundFile* file,void* data, DLong sizeInBytes);
+DSFML_AUDIO_API DBool sfInputSoundFile_openFromMemory(sfInputSoundFile* file,
+                                                      void* data,
+                                                      DLong sizeInBytes);
 
 //Open a sound file from a custom stream for reading
-DSFML_AUDIO_API DBool sfInputSoundFile_openFromStream(sfInputSoundFile* file, DStream* stream);
+DSFML_AUDIO_API DBool sfInputSoundFile_openFromStream(sfInputSoundFile* file,
+                                                      DStream* stream);
 
 //Read samples from a sound file
-DSFML_AUDIO_API DLong sfInputSoundFile_read(sfInputSoundFile* file, DShort* data, DLong sampleCount);
+DSFML_AUDIO_API DLong sfInputSoundFile_read(sfInputSoundFile* file, DShort* data,
+                                            DLong sampleCount);
 
 //Change the current read position in the sound file
-DSFML_AUDIO_API void sfInputSoundFile_seek(sfInputSoundFile* file, DLong timeOffset);
-
+DSFML_AUDIO_API void sfInputSoundFile_seek(sfInputSoundFile* file,
+                                           DLong timeOffset);
 
 #endif // DSFML_INPUTSOUNDFILE_H

--- a/include/DSFMLC/Audio/InternalSoundRecorder.hpp
+++ b/include/DSFMLC/Audio/InternalSoundRecorder.hpp
@@ -1,37 +1,33 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_INTERNALSOUNDRECORDER_HPP
 #define DSFML_INTERNALSOUNDRECORDER_HPP
 
-//Headers
 #include <DSFMLC/Config.h>
 #include <vector>
 
@@ -61,9 +57,8 @@ public:
     static DBool isAvailable();
 
 private:
-    std::vector<DShort> m_samples;//Vector that stores recorded samples
-
-
+    //Vector that stores recorded samples
+    std::vector<DShort> m_samples;
 };
 
 #endif // DSFML_INTERNALSOUNDRECORDER_HPP

--- a/include/DSFMLC/Audio/Listener.h
+++ b/include/DSFMLC/Audio/Listener.h
@@ -1,37 +1,33 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_AUDIO_LISTENER_H
 #define DSFML_AUDIO_LISTENER_H
 
-//Headers
 #include <DSFMLC/Audio/Export.h>
 
 //Set the global volume

--- a/include/DSFMLC/Audio/OutputSoundFile.h
+++ b/include/DSFMLC/Audio/OutputSoundFile.h
@@ -1,37 +1,33 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_OUTPUTSOUNDFILE_H
 #define DSFML_OUTPUTSOUNDFILE_H
 
-//Headers
 #include <DSFMLC/Audio/Export.h>
 #include <DSFMLC/Audio/Types.h>
 #include <stddef.h>
@@ -47,6 +43,5 @@ DSFML_AUDIO_API DBool sfOutputSoundFile_openFromFile(sfOutputSoundFile* file, co
 
 //Write samples to a sound file
 DSFML_AUDIO_API void sfOutputSoundFile_write(sfOutputSoundFile* file, const DShort* data, DLong sampleCount);
-
 
 #endif // DSFML_OUTPUTSOUNDFILE_H

--- a/include/DSFMLC/Audio/Sound.h
+++ b/include/DSFMLC/Audio/Sound.h
@@ -1,7 +1,7 @@
 /*
 DSFML - The Simple and Fast Multimedia Library for D
 
-Copyright (c) <2013> <Jeremy DeHaan>
+Copyright (c) <2018> <Jeremy DeHaan>
 
 This software is provided 'as-is', without any express or implied warranty.
 In no event will the authors be held liable for any damages arising from the use of this software.
@@ -23,7 +23,7 @@ If you use this software in a product, an acknowledgment in the product document
 External Libraries Used:
 
 SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
+Copyright (C) 2007-2018 Laurent Gomila (laurent.gom@gmail.com)
 
 All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
 */

--- a/include/DSFMLC/Audio/SoundBuffer.h
+++ b/include/DSFMLC/Audio/SoundBuffer.h
@@ -1,7 +1,7 @@
 /*
 DSFML - The Simple and Fast Multimedia Library for D
 
-Copyright (c) <2013> <Jeremy DeHaan>
+Copyright (c) <2018> <Jeremy DeHaan>
 
 This software is provided 'as-is', without any express or implied warranty.
 In no event will the authors be held liable for any damages arising from the use of this software.
@@ -23,7 +23,7 @@ If you use this software in a product, an acknowledgment in the product document
 External Libraries Used:
 
 SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
+Copyright (C) 2007-2018 Laurent Gomila (laurent.gom@gmail.com)
 
 All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
 */

--- a/include/DSFMLC/Audio/SoundRecorder.h
+++ b/include/DSFMLC/Audio/SoundRecorder.h
@@ -1,7 +1,7 @@
 /*
 DSFML - The Simple and Fast Multimedia Library for D
 
-Copyright (c) <2013> <Jeremy DeHaan>
+Copyright (c) <2018> <Jeremy DeHaan>
 
 This software is provided 'as-is', without any express or implied warranty.
 In no event will the authors be held liable for any damages arising from the use of this software.
@@ -23,7 +23,7 @@ If you use this software in a product, an acknowledgment in the product document
 External Libraries Used:
 
 SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
+Copyright (C) 2007-2018 Laurent Gomila (laurent.gom@gmail.com)
 
 All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
 */

--- a/include/DSFMLC/Audio/SoundSource.h
+++ b/include/DSFMLC/Audio/SoundSource.h
@@ -1,42 +1,35 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_SOUNDSOURCE_H
 #define DSFML_SOUNDSOURCE_H
 
-
-#include <DSFMLC/Audio/ALCheck.hpp>
 #include <DSFMLC/Audio/Export.h>
 #include <SFML/Audio/SoundSource.hpp>
-
-
 
 //Define the audio methods used within sf::SoundSource
 
@@ -55,8 +48,6 @@ DSFML_AUDIO_API void sfSoundSource_setRelativeToListener(DUint sourceID,DBool re
 DSFML_AUDIO_API void sfSoundSource_setMinDistance(DUint sourceID, float distance);
 
 DSFML_AUDIO_API void sfSoundSource_setAttenuation(DUint sourceID, float attenuation);
-
-
 
 DSFML_AUDIO_API float sfSoundSource_getPitch(DUint sourceID);
 

--- a/include/DSFMLC/Audio/SoundStream.h
+++ b/include/DSFMLC/Audio/SoundStream.h
@@ -1,32 +1,29 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_SOUNDSTREAM_H
 #define DSFML_SOUNDSTREAM_H
@@ -84,4 +81,5 @@ DSFML_AUDIO_API float sfSoundStream_getAttenuation(const sfSoundStream* soundStr
 DSFML_AUDIO_API DBool sfSoundStream_getLoop(const sfSoundStream* soundStream);
 
 DSFML_AUDIO_API DLong sfSoundStream_getPlayingOffset(const sfSoundStream* soundStream);
+
 #endif // DSFML_SOUNDSTREAM_H

--- a/include/DSFMLC/Audio/Types.h
+++ b/include/DSFMLC/Audio/Types.h
@@ -1,32 +1,29 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_AUDIO_TYPES_H
 #define DSFML_AUDIO_TYPES_H

--- a/include/DSFMLC/Config.h
+++ b/include/DSFMLC/Config.h
@@ -1,57 +1,48 @@
-////////////////////////////////////////////////////////////
-//
-// SFML - Simple and Fast Multimedia Library
-// Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-//
-// This software is provided 'as-is', without any express or implied warranty.
-// In no event will the authors be held liable for any damages arising from the use of this software.
-//
-// Permission is granted to anyone to use this software for any purpose,
-// including commercial applications, and to alter it and redistribute it freely,
-// subject to the following restrictions:
-//
-// 1. The origin of this software must not be misrepresented;
-//    you must not claim that you wrote the original software.
-//    If you use this software in a product, an acknowledgment
-//    in the product documentation would be appreciated but is not required.
-//
-// 2. Altered source versions must be plainly marked as such,
-//    and must not be misrepresented as being the original software.
-//
-// 3. This notice may not be removed or altered from any source distribution.
-//
-////////////////////////////////////////////////////////////
+/*
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_CONFIG_H
 #define DSFML_CONFIG_H
 
 #include <SFML/Config.hpp>
 
-
-
-
-////////////////////////////////////////////////////////////
-// Define portable fixed-size types
-////////////////////////////////////////////////////////////
-
-// Redefine D's types using the same method SFML does.
-
+/// Define portable fixed-size types for D
 
 // 8 bits integer types
 typedef signed char  DByte;
 typedef unsigned char DUbyte;
 
-
-
 // 16 bits integer types
 typedef signed short  DShort;
 typedef unsigned short DUshort;
 
-
 // 32 bits integer types
 typedef signed int  DInt;
 typedef unsigned int DUint;
-
 
 // 64 bits integer types
 #if defined(_MSC_VER)
@@ -65,16 +56,9 @@ typedef unsigned int DUint;
 // 32 Bit wide character(dchar)
 typedef DUint DChar;
 
-
-
-////////////////////////////////////////////////////////////
-// Define a boolean that is compatible with D
-////////////////////////////////////////////////////////////
-
+//Define a boolean that is compatible with D
 typedef DUbyte DBool;
-
 #define DFalse 0
 #define DTrue  1
-
 
 #endif // SFML_CONFIG_H

--- a/include/DSFMLC/ConvertEvent.h
+++ b/include/DSFMLC/ConvertEvent.h
@@ -1,46 +1,42 @@
-////////////////////////////////////////////////////////////
-//
-// SFML - Simple and Fast Multimedia Library
-// Copyright (C) 2007-2009 Laurent Gomila (laurent.gom@gmail.com)
-//
-// This software is provided 'as-is', without any express or implied warranty.
-// In no event will the authors be held liable for any damages arising from the use of this software.
-//
-// Permission is granted to anyone to use this software for any purpose,
-// including commercial applications, and to alter it and redistribute it freely,
-// subject to the following restrictions:
-//
-// 1. The origin of this software must not be misrepresented;
-//    you must not claim that you wrote the original software.
-//    If you use this software in a product, an acknowledgment
-//    in the product documentation would be appreciated but is not required.
-//
-// 2. Altered source versions must be plainly marked as such,
-//    and must not be misrepresented as being the original software.
-//
-// 3. This notice may not be removed or altered from any source distribution.
-//
-////////////////////////////////////////////////////////////
+/*
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_CONVERTEVENT_H
 #define DSFML_CONVERTEVENT_H
 
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
 #include <SFML/Window/Event.hpp>
 #include <DSFMLC/Window/Event.h>
 
 
-
-////////////////////////////////////////////////////////////
-// Define a function to convert a sf::Event ot a sfEvent
-////////////////////////////////////////////////////////////
+//Define a function to convert a sf::Event ot a sfEvent
 inline void convertEvent(const sf::Event& SFMLEvent, DEvent* event)
 {
     // Convert its type
     event->type = static_cast<DEvent::EventType>(SFMLEvent.type);
-
 
     // Fill its fields
     switch (event->type)
@@ -104,4 +100,3 @@ inline void convertEvent(const sf::Event& SFMLEvent, DEvent* event)
 }
 
 #endif // DSFML_CONVERTEVENT_H
-

--- a/include/DSFMLC/Graphics/Err.h
+++ b/include/DSFMLC/Graphics/Err.h
@@ -1,37 +1,33 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_ERR_H
 #define DSFML_ERR_H
 
-//Headers
 #include <DSFMLC/Graphics/Export.h>
 
 //Redirect sf::err() so that its output can be gotten later

--- a/include/DSFMLC/Graphics/Export.h
+++ b/include/DSFMLC/Graphics/Export.h
@@ -1,54 +1,35 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef SFML_GRAPHICS_EXPORT_H
 #define SFML_GRAPHICS_EXPORT_H
 
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
 #include <DSFMLC/Config.h>
 
-
-////////////////////////////////////////////////////////////
-// Define portable import / export macros
-////////////////////////////////////////////////////////////
-//If we define DSFML_NETWORK_EXPORTS
-#if defined(DSFML_GRAPHICS_EXPORTS)
-	//We need to make sure the SFML_NETWORK_EXPORTS is defined as well
-	//#define SFML_GRAPHICS_EXPORTS 
-#endif
-
-//Then we define out D export. Will work for shared and static builds (since for static SFML_API_EXPORT is just empty)
 #define DSFML_GRAPHICS_API extern "C" SFML_API_EXPORT
-
-
 
 #endif // SFML_GRAPHICS_EXPORT_H

--- a/include/DSFMLC/Graphics/Font.h
+++ b/include/DSFMLC/Graphics/Font.h
@@ -1,38 +1,33 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef SFML_FONT_H
 #define SFML_FONT_H
 
-
-// Headers
 #include <DSFMLC/Graphics/Export.h>
 #include <DSFMLC/Graphics/Types.h>
 #include <DSFMLC/System/DStream.hpp>
@@ -44,30 +39,23 @@ DSFML_GRAPHICS_API sfFont* sfFont_construct(void);
 //Load a new font from a file
 DSFML_GRAPHICS_API DBool sfFont_loadFromFile(sfFont* font, const char* filename, size_t length);
 
-
 //Load a new image font a file in memory
 DSFML_GRAPHICS_API DBool sfFont_loadFromMemory(sfFont* font, const void* data, size_t sizeInBytes);
-
 
 //Load a new image font a custom stream
 DSFML_GRAPHICS_API DBool sfFont_loadFromStream(sfFont* font, DStream* stream);
 
-
 // Copy an existing font
 DSFML_GRAPHICS_API sfFont* sfFont_copy(const sfFont* font);
-
 
 //Destroy an existing font
 DSFML_GRAPHICS_API void sfFont_destroy(sfFont* font);
 
-
 //Get a glyph in a font
 DSFML_GRAPHICS_API void sfFont_getGlyph(const sfFont* font, DUint codePoint, DInt characterSize, DBool bold, float* glyphAdvance, float* glyphBoundsLeft, float* glyphBoundsTop, float* glyphBoundsWidth, float* glyphBoundsHeight, DInt* glyphTextRectLeft, DInt* glyphTextRectTop, DInt* glyphTextRectWidth, DInt* glyphTextRectHeight);
 
-
 //Get the kerning value corresponding to a given pair of characters in a font
 DSFML_GRAPHICS_API float sfFont_getKerning(const sfFont* font, DUint first, DUint second, DUint characterSize);
-
 
 //Get the line spacing value
 DSFML_GRAPHICS_API float sfFont_getLineSpacing(const sfFont* font, DUint characterSize);
@@ -81,9 +69,7 @@ DSFML_GRAPHICS_API float sfFont_getUnderlineThickness (const sfFont * font, DUin
 //Get the texture pointer for a particular font
 DSFML_GRAPHICS_API sfTexture* sfFont_getTexturePtr(const sfFont* font);
 
-
 //Update the internal texture associated with the font
 DSFML_GRAPHICS_API void sfFont_updateTexture(const sfFont* font, DUint characterSize);
-
 
 #endif // SFML_IMAGE_H

--- a/include/DSFMLC/Graphics/Image.h
+++ b/include/DSFMLC/Graphics/Image.h
@@ -1,37 +1,33 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef SFML_IMAGE_H
 #define SFML_IMAGE_H
 
-// Headers
 #include <DSFMLC/Graphics/Export.h>
 #include <DSFMLC/Graphics/Types.h>
 #include <DSFMLC/System/DStream.hpp>

--- a/include/DSFMLC/Graphics/RenderTexture.h
+++ b/include/DSFMLC/Graphics/RenderTexture.h
@@ -1,37 +1,33 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef SFML_RENDERTEXTURE_H
 #define SFML_RENDERTEXTURE_H
 
-// Headers
 #include <DSFMLC/Graphics/Export.h>
 #include <DSFMLC/Graphics/Types.h>
 
@@ -95,6 +91,5 @@ DSFML_GRAPHICS_API void sfRenderTexture_setSmooth(sfRenderTexture* renderTexture
 
 //  Tell whether the smooth filter is enabled or not for a render texture
 DSFML_GRAPHICS_API DBool sfRenderTexture_isSmooth(const sfRenderTexture* renderTexture);
-
 
 #endif // SFML_RENDERTEXTURE_H

--- a/include/DSFMLC/Graphics/RenderWindow.h
+++ b/include/DSFMLC/Graphics/RenderWindow.h
@@ -1,37 +1,33 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef SFML_RENDERWINDOW_H
 #define SFML_RENDERWINDOW_H
 
-// Headers
 #include <DSFMLC/Graphics/Export.h>
 #include <DSFMLC/Graphics/Types.h>
 #include <DSFMLC/Window/Event.h>
@@ -162,6 +158,5 @@ DSFML_GRAPHICS_API void sfMouse_getPositionRenderWindow(const sfRenderWindow* re
 
 //Set the current position of the mouse relatively to a render-window
 DSFML_GRAPHICS_API void sfMouse_setPositionRenderWindow(DInt x, DInt y, const sfRenderWindow* relativeTo);
-
 
 #endif // SFML_RENDERWINDOW_H

--- a/include/DSFMLC/Graphics/Shader.h
+++ b/include/DSFMLC/Graphics/Shader.h
@@ -1,38 +1,33 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef SFML_SHADER_H
 #define SFML_SHADER_H
 
-
-// Headers
 #include <DSFMLC/Graphics/Export.h>
 #include <DSFMLC/Graphics/Types.h>
 #include <DSFMLC/System/DStream.hpp>
@@ -45,110 +40,83 @@ DSFML_GRAPHICS_API sfShader* sfShader_construct(void);
 //Load both the vertex and fragment shaders from files
 DSFML_GRAPHICS_API DBool sfShader_loadFromFile(sfShader* shader, const char* vertexShaderFilename, size_t vertexShaderFilenameLength, const char* fragmentShaderFilename, size_t fragmentShaderFilenameLength);
 
-
 //Load both the vertex and fragment shaders from source codes in memory
 DSFML_GRAPHICS_API DBool sfShader_loadFromMemory(sfShader* shader, const char* vertexShader, size_t vertexShaderLength, const char* fragmentShader, size_t fragmentShaderLength);
-
 
 //Load both the vertex and fragment shaders from custom streams
 DSFML_GRAPHICS_API DBool sfShader_loadFromStream(sfShader* shader, DStream* vertexShaderStream, DStream* fragmentShaderStream);
 
-
 //Destroy an existing shader
 DSFML_GRAPHICS_API void sfShader_destroy(sfShader* shader);
-
 
 //Specify value for float uniform
 DSFML_GRAPHICS_API void sfShader_setFloatUniform(sfShader* shader, const char* name, size_t length, float x);
 
-
 //Specify value for vec2 uniform
 DSFML_GRAPHICS_API void sfShader_setVec2Uniform(sfShader* shader, const char* name, size_t length, const sf::Glsl::Vec2* vec2);
-
 
 //Specify value for vec3 uniform
 DSFML_GRAPHICS_API void sfShader_setVec3Uniform(sfShader* shader, const char* name, size_t length, const sf::Glsl::Vec3* vec3);
 
-
 //Specify value for vec4 uniform
 DSFML_GRAPHICS_API void sfShader_setVec4Uniform(sfShader* shader, const char* name, size_t length, const sf::Glsl::Vec4* vec4);
-
 
 //Specify value for int uniform
 DSFML_GRAPHICS_API void sfShader_setIntUniform(sfShader* shader, const char* name, size_t length, int x);
 
-
 //Specify value for ivec2 uniform
 DSFML_GRAPHICS_API void sfShader_setIvec2Uniform(sfShader* shader, const char* name, size_t length, const sf::Glsl::Ivec2* ivec2);
-
 
 //Specify value for ivec3 uniform
 DSFML_GRAPHICS_API void sfShader_setIvec3Uniform(sfShader* shader, const char* name, size_t length, const sf::Glsl::Ivec3* ivec3);
 
-
 //Specify value for ivec4 uniform
 DSFML_GRAPHICS_API void sfShader_setIvec4Uniform(sfShader* shader, const char* name, size_t length, const sf::Glsl::Ivec4* ivec4);
-
 
 //Specify value for bool uniform
 DSFML_GRAPHICS_API void sfShader_setBoolUniform(sfShader* shader, const char* name, size_t length, DBool x);
 
-
 //Specify value for bvec2 uniform
 DSFML_GRAPHICS_API void sfShader_setBvec2Uniform(sfShader* shader, const char* name, size_t length, DBool x, DBool y);
-
 
 //Specify value for bvec3 uniform
 DSFML_GRAPHICS_API void sfShader_setBvec3Uniform(sfShader* shader, const char* name, size_t length, DBool x, DBool y, DBool z);
 
-
 //Specify value for bvec4 uniform
 DSFML_GRAPHICS_API void sfShader_setBvec4Uniform(sfShader* shader, const char* name, size_t length, DBool x, DBool y, DBool z, DBool w);
-
 
 //Specify value for mat3 matrix.
 DSFML_GRAPHICS_API void sfShader_setMat3Uniform(sfShader* shader, const char* name, size_t length, const sf::Glsl::Mat3* mat3);
 
-
 //Specify value for mat4 matrix.
 DSFML_GRAPHICS_API void sfShader_setMat4Uniform(sfShader* shader, const char* name, size_t length, const sf::Glsl::Mat4* mat4);
-
 
 //Specify a texture as sampler2D uniform
 DSFML_GRAPHICS_API void sfShader_setTextureUniform(sfShader* shader, const char* name, size_t length, const sfTexture* texture);
 
-
 //Specify current texture as sampler2D uniform.
 DSFML_GRAPHICS_API void sfShader_setCurrentTextureUniform(sfShader* shader, const char* name, size_t length);
-
 
 //Specify values for float[] array uniform.
 DSFML_GRAPHICS_API void sfShader_setFloatArrayUniform(sfShader* shader, const char* name, size_t nlength, const float* array, size_t alength);
 
-
 //Specify values for vec2[] array uniform.
 DSFML_GRAPHICS_API void sfShader_setVec2ArrayUniform(sfShader* shader, const char* name, size_t nlength, const sf::Glsl::Vec2*, size_t alength);
-
 
 //Specify values for vec3[] array uniform.
 DSFML_GRAPHICS_API void sfShader_setVec3ArrayUniform(sfShader* shader, const char* name, size_t nlength, const sf::Glsl::Vec3*, size_t alength);
 
-
 //Specify values for vec4[] array uniform.
 DSFML_GRAPHICS_API void sfShader_setVec4ArrayUniform(sfShader* shader, const char* name, size_t nlength, const sf::Glsl::Vec4*, size_t alength);
-
 
 //Specify values for mat3[] array uniform.
 DSFML_GRAPHICS_API void sfShader_setMat3ArrayUniform(sfShader* shader, const char* name, size_t nlength, const sf::Glsl::Mat3*, size_t alength);
 
-
 //Specify values for mat4[] array uniform.
 DSFML_GRAPHICS_API void sfShader_setMat4ArrayUniform(sfShader* shader, const char* name, size_t nlength, const sf::Glsl::Mat4*, size_t alength);
 
-
 //Bind a shader for rendering (activate it)
 DSFML_GRAPHICS_API void sfShader_bind(const sfShader* shader);
-
 
 //Tell whether or not the system supports shaders
 DSFML_GRAPHICS_API DBool sfShader_isAvailable(void);
@@ -159,33 +127,25 @@ DSFML_GRAPHICS_API DBool sfShader_isAvailable(void);
 //Change a float parameter of a shader
 DSFML_GRAPHICS_API void sfShader_setFloatParameter(sfShader* shader, const char* name, size_t length, float x);
 
-
 //Change a 2-components vector parameter of a shader
 DSFML_GRAPHICS_API void sfShader_setFloat2Parameter(sfShader* shader, const char* name, size_t length, float x, float y);
-
 
 //Change a 3-components vector parameter of a shader
 DSFML_GRAPHICS_API void sfShader_setFloat3Parameter(sfShader* shader, const char* name, size_t length, float x, float y, float z);
 
-
 //Change a 4-components vector parameter of a shader
 DSFML_GRAPHICS_API void sfShader_setFloat4Parameter(sfShader* shader, const char* name, size_t length, float x, float y, float z, float w);
-
 
 //Change a color parameter of a shader
 DSFML_GRAPHICS_API void sfShader_setColorParameter(sfShader* shader, const char* name, size_t length, DUbyte r, DUbyte g, DUbyte b, DUbyte a);
 
-
 //Change a matrix parameter of a shader
 DSFML_GRAPHICS_API void sfShader_setTransformParameter(sfShader* shader, const char* name, size_t length, float* transform);
-
 
 //Change a texture parameter of a shader
 DSFML_GRAPHICS_API void sfShader_setTextureParameter(sfShader* shader, const char* name, size_t length, const sfTexture* texture);
 
-
 //Change a texture parameter of a shader
 DSFML_GRAPHICS_API void sfShader_setCurrentTextureParameter(sfShader* shader, const char* name, size_t length);
-
 
 #endif // SFML_SHADER_H

--- a/include/DSFMLC/Graphics/Text.h
+++ b/include/DSFMLC/Graphics/Text.h
@@ -1,44 +1,37 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_TEXT_H
 #define DSFML_TEXT_H
 
-
-// Headers
 #include <DSFMLC/Graphics/Export.h>
 #include <DSFMLC/Graphics/Types.h>
 #include <DSFMLC/Graphics/Transform.h>
 #include <stddef.h>
-
-
 
 /// sfText styles
 typedef enum
@@ -50,141 +43,106 @@ typedef enum
 } sfTextStyle;
 
 
-
 //Create a new text
 DSFML_GRAPHICS_API sfText* sfText_construct(void);
-
 
 //Copy an existing text
 DSFML_GRAPHICS_API sfText* sfText_copy(const sfText* text);
 
-
 //Destroy an existing text
 DSFML_GRAPHICS_API void sfText_destroy(sfText* text);
 
-
-/// \brief Set the position of a text
+//Set the position of a text
 DSFML_GRAPHICS_API void sfText_setPosition(sfText* text, float positionX, float positionY);
 
-
-/// \brief Set the orientation of a text
+//Set the orientation of a text
 DSFML_GRAPHICS_API void sfText_setRotation(sfText* text, float angle);
 
-
-/// \brief Set the scale factors of a text
+//Set the scale factors of a text
 DSFML_GRAPHICS_API void sfText_setScale(sfText* text, float scaleX, float scaleY);
 
-
-/// \brief Set the local origin of a text
+//Set the local origin of a text
 DSFML_GRAPHICS_API void sfText_setOrigin(sfText* text, float originX, float originY);
 
-
-/// \brief Get the position of a text
+//Get the position of a text
 DSFML_GRAPHICS_API void sfText_getPosition(const sfText* text, float* positionX, float* positionY);
 
-
-/// \brief Get the orientation of a text
+//Get the orientation of a text
 DSFML_GRAPHICS_API float sfText_getRotation(const sfText* text);
 
-
-/// \brief Get the current scale of a text
+//Get the current scale of a text
 DSFML_GRAPHICS_API void sfText_getScale(const sfText* text, float* scaleX, float* scaleY);
 
-
-/// \brief Get the local origin of a text
+//Get the local origin of a text
 DSFML_GRAPHICS_API void sfText_getOrigin(const sfText* text, float* originX, float* originY);
 
-
-/// \brief Move a text by a given offset
+//Move a text by a given offset
 DSFML_GRAPHICS_API void sfText_move(sfText* text, float offsetX, float offsetY);
 
-
-/// \brief Rotate a text
+//Rotate a text
 DSFML_GRAPHICS_API void sfText_rotate(sfText* text, float angle);
 
-
-/// \brief Scale a text
+//Scale a text
 DSFML_GRAPHICS_API void sfText_scale(sfText* text, float factorX, float factorY);
 
-
-/// \brief Get the combined transform of a text
+//Get the combined transform of a text
 DSFML_GRAPHICS_API void sfText_getTransform(const sfText* text, float* transform);
 
-
-/// \brief Get the inverse of the combined transform of a text
+//Get the inverse of the combined transform of a text
 DSFML_GRAPHICS_API void sfText_getInverseTransform(const sfText* text, float* transform);
 
-
-/// \brief Set the string of a text (from an ANSI string)
+//Set the string of a text (from an ANSI string)
 DSFML_GRAPHICS_API void sfText_setString(sfText* text, const char* string);
 
-
-/// \brief Set the string of a text (from a unicode string)
+//Set the string of a text (from a unicode string)
 DSFML_GRAPHICS_API void sfText_setUnicodeString(sfText* text, const DUint* string);
 
-
-/// \brief Set the font of a text
+//Set the font of a text
 DSFML_GRAPHICS_API void sfText_setFont(sfText* text, const sfFont* font);
 
-
-/// \brief Set the character size of a text
+//Set the character size of a text
 DSFML_GRAPHICS_API void sfText_setCharacterSize(sfText* text, DUint size);
 
-
-/// \brief Set the style of a text
+//Set the style of a text
 DSFML_GRAPHICS_API void sfText_setStyle(sfText* text, DUint style);
 
-
-/// \brief Set the global color of a text
+//Set the global color of a text
 DSFML_GRAPHICS_API void sfText_setColor(sfText* text, DUbyte r, DUbyte g, DUbyte b, DUbyte a);
 
-
-/// \brief Get the string of a text (returns an ANSI string)
+//Get the string of a text (returns an ANSI string)
 DSFML_GRAPHICS_API const char* sfText_getString(const sfText* text);
 
-
-/// \brief Get the string of a text (returns a unicode string)
+//Get the string of a text (returns a unicode string)
 DSFML_GRAPHICS_API const DUint* sfText_getUnicodeString(const sfText* text);
 
-
-/// \brief Get the font used by a text
+//Get the font used by a text
 DSFML_GRAPHICS_API sfFont* sfText_getFont(const sfText* text);
 
-
-/// \brief Get the size of the characters of a text
+//Get the size of the characters of a text
 DSFML_GRAPHICS_API DUint sfText_getCharacterSize(const sfText* text);
 
-
-/// \brief Get the style of a text
+//Get the style of a text
 DSFML_GRAPHICS_API DUint sfText_getStyle(const sfText* text);
 
-
-/// \brief Get the global color of a text
+//Get the global color of a text
 DSFML_GRAPHICS_API void sfText_getColor(const sfText* text, DUbyte* r, DUbyte* g, DUbyte* b, DUbyte* a);
 
-
-/// \brief Return the position of the \a index-th character in a text
+//Return the position of the \a index-th character in a text
 DSFML_GRAPHICS_API void sfText_findCharacterPos(const sfText* text, size_t index, float* posX, float* posY);
 
-
-/// \brief Get the local bounding rectangle of a text
+//Get the local bounding rectangle of a text
 DSFML_GRAPHICS_API void sfText_getLocalBounds(const sfText* text, float* left, float* top, float* width, float* height);
 
-
-/// \brief Get the global bounding rectangle of a text
+//Get the global bounding rectangle of a text
 DSFML_GRAPHICS_API void sfText_getGlobalBounds(const sfText* text, float* left, float* top, float* width, float* height);
-
 
 //Get the array of vertices this Text uses for drawing
 DSFML_GRAPHICS_API const void* sfText_getVertexArray(const sfText* text);
 
-
 //Get the number of vertices this Text uses for drawing
 DSFML_GRAPHICS_API DUint sfText_getVertexCount(const sfText* text);
 
-    
 //Get the PrimitiveType this Text uses for drawing
 DSFML_GRAPHICS_API DInt sfText_getPrimitiveType(const sfText* text);
-
 
 #endif // SFML_TEXT_H

--- a/include/DSFMLC/Graphics/Texture.h
+++ b/include/DSFMLC/Graphics/Texture.h
@@ -1,37 +1,33 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_TEXTURE_H
 #define DSFML_TEXTURE_H
 
-// Headers
 #include <DSFMLC/Graphics/Export.h>
 #include <DSFMLC/Graphics/Types.h>
 #include <DSFMLC/Window/Types.h>

--- a/include/DSFMLC/Graphics/Transform.h
+++ b/include/DSFMLC/Graphics/Transform.h
@@ -1,41 +1,35 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_TRANSFORM_H
 #define DSFML_TRANSFORM_H
 
-// Headers
 #include <DSFMLC/Graphics/Export.h>
 #include <DSFMLC/Graphics/Types.h>
-
-
 
 //Return the 4x4 matrix of a transform
 DSFML_GRAPHICS_API void sfTransform_getMatrix(const float* transform, float* matrix);

--- a/include/DSFMLC/Graphics/Types.h
+++ b/include/DSFMLC/Graphics/Types.h
@@ -1,45 +1,38 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_GRAPHICS_TYPES_H
 #define DSFML_GRAPHICS_TYPES_H
 
-
-
 typedef struct sfFont sfFont;
 typedef struct sfImage sfImage;
 typedef struct sfShader sfShader;
-
 typedef struct sfRenderTexture sfRenderTexture;
 typedef struct sfRenderWindow sfRenderWindow;
-
 typedef struct sfSprite sfSprite;
 typedef struct sfText sfText;
 typedef struct sfTexture sfTexture;

--- a/include/DSFMLC/Network/Err.h
+++ b/include/DSFMLC/Network/Err.h
@@ -1,37 +1,33 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_ERR_H
 #define DSFML_ERR_H
 
-//Headers
 #include <DSFMLC/Network/Export.h>
 
 //Redirect sf::err() so that its output can be gotten later

--- a/include/DSFMLC/Network/Export.h
+++ b/include/DSFMLC/Network/Export.h
@@ -1,50 +1,35 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on Laurent Gomila's SFML library.***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DFML_NETWORK_EXPORT_H
 #define DFML_NETWORK_EXPORT_H
 
-// Headers
 #include <DSFMLC/Config.h>
 
-//If we define DSFML_NETWORK_EXPORTS
-#if defined(DSFML_NETWORK_EXPORTS)
-	//We need to make sure the SFML_NETWORK_EXPORTS is defined as well
-	//#define SFML_NETWORK_EXPORTS
-#endif
-
-//Then we define out D export. Will work for shared and static builds (since for static SFML_API_EXPORT is just empty)
 #define DSFML_NETWORK_API extern "C" SFML_API_EXPORT
-
-
-
-
 
 #endif // DFML_NETWORK_EXPORT_H

--- a/include/DSFMLC/Network/Ftp.h
+++ b/include/DSFMLC/Network/Ftp.h
@@ -1,38 +1,33 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on Laurent Gomila's SFML library.***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_FTP_H
 #define DSFML_FTP_H
 
-
-// Headers
 #include <DSFMLC/Network/Export.h>
 #include <DSFMLC/Network/IpAddress.h>
 #include <DSFMLC/Network/Types.h>
@@ -44,128 +39,97 @@ All Libraries used by SFML
 //Destroy a FTP listing response
 DSFML_NETWORK_API void sfFtpListingResponse_destroy(sfFtpListingResponse* ftpListingResponse);
 
-
 //Get the status code of a FTP listing response
 DSFML_NETWORK_API DInt sfFtpListingResponse_getStatus(const sfFtpListingResponse* ftpListingResponse);
-
 
 //Get the full message contained in a FTP listing response
 DSFML_NETWORK_API const char* sfFtpListingResponse_getMessage(const sfFtpListingResponse* ftpListingResponse);
 
-
 //Return the number of directory/file names contained in a FTP listing response
 DSFML_NETWORK_API size_t sfFtpListingResponse_getCount(const sfFtpListingResponse* ftpListingResponse);
 
-
 //Return a directory/file name contained in a FTP listing response
 DSFML_NETWORK_API const char* sfFtpListingResponse_getName(const sfFtpListingResponse* ftpListingResponse, size_t index);
-
-
 
 ///FTP Directory Responce Functions
 
 //Destroy a FTP directory response
 DSFML_NETWORK_API void sfFtpDirectoryResponse_destroy(sfFtpDirectoryResponse* ftpDirectoryResponse);
 
-
 //Get the status code of a FTP directory response
 DSFML_NETWORK_API DInt sfFtpDirectoryResponse_getStatus(const sfFtpDirectoryResponse* ftpDirectoryResponse);
-
 
 //Get the full message contained in a FTP directory response
 DSFML_NETWORK_API const char* sfFtpDirectoryResponse_getMessage(const sfFtpDirectoryResponse* ftpDirectoryResponse);
 
-
 //Get the directory returned in a FTP directory response
 DSFML_NETWORK_API const char* sfFtpDirectoryResponse_getDirectory(const sfFtpDirectoryResponse* ftpDirectoryResponse);
-
-
 
 ///FTP Responce functions
 
 //Destroy a FTP response
 DSFML_NETWORK_API void sfFtpResponse_destroy(sfFtpResponse* ftpResponse);
 
-
 //Get the status code of a FTP response
 DSFML_NETWORK_API DInt sfFtpResponse_getStatus(const sfFtpResponse* ftpResponse);
 
-
 //Get the full message contained in a FTP response
 DSFML_NETWORK_API const char* sfFtpResponse_getMessage(const sfFtpResponse* ftpResponse);
-
 
 ///FTP functions
 
 //Create a new Ftp object
 DSFML_NETWORK_API sfFtp* sfFtp_create(void);
 
-
 //Destroy a Ftp object
 DSFML_NETWORK_API void sfFtp_destroy(sfFtp* ftp);
-
 
 //Connect to the specified FTP server
 DSFML_NETWORK_API sfFtpResponse* sfFtp_connect(sfFtp* ftp, sf::IpAddress* serverIP, DUshort port, DLong timeout);
 
-
 //Log in using an anonymous account
 DSFML_NETWORK_API sfFtpResponse* sfFtp_loginAnonymous(sfFtp* ftp);
-
 
 //Log in using a username and a password
 DSFML_NETWORK_API sfFtpResponse* sfFtp_login(sfFtp* ftp, const char* userName, size_t userNameLength, const char* password, size_t passwordLength);
 
-
 //Close the connection with the server
 DSFML_NETWORK_API sfFtpResponse* sfFtp_disconnect(sfFtp* ftp);
-
 
 //Send a null command to keep the connection alive
 DSFML_NETWORK_API sfFtpResponse* sfFtp_keepAlive(sfFtp* ftp);
 
-
 //Get the current working directory
 DSFML_NETWORK_API sfFtpDirectoryResponse* sfFtp_getWorkingDirectory(sfFtp* ftp);
-
 
 //Get the contents of the given directory
 DSFML_NETWORK_API sfFtpListingResponse* sfFtp_getDirectoryListing(sfFtp* ftp, const char* directory, size_t length);
 
-
 //Change the current working directory
 DSFML_NETWORK_API sfFtpResponse* sfFtp_changeDirectory(sfFtp* ftp, const char* directory, size_t length);
-
 
 //Go to the parent directory of the current one
 DSFML_NETWORK_API sfFtpResponse* sfFtp_parentDirectory(sfFtp* ftp);
 
-
 //Create a new directory
 DSFML_NETWORK_API sfFtpResponse* sfFtp_createDirectory(sfFtp* ftp, const char* name, size_t length);
-
 
 //Remove an existing directory
 DSFML_NETWORK_API sfFtpResponse* sfFtp_deleteDirectory(sfFtp* ftp, const char* name, size_t length);
 
-
 //Rename an existing file
 DSFML_NETWORK_API sfFtpResponse* sfFtp_renameFile(sfFtp* ftp, const char* file, size_t fileLength, const char* newName, size_t newNameLength);
-
 
 //Remove an existing file
 DSFML_NETWORK_API sfFtpResponse* sfFtp_deleteFile(sfFtp* ftp, const char* name, size_t length);
 
-
 //Download a file from a FTP server
 DSFML_NETWORK_API sfFtpResponse* sfFtp_download(sfFtp* ftp, const char* distantFile, size_t distantFileLength, const char* destPath, size_t destpathLength, DInt mode);
-
 
 //Upload a file to a FTP server
 DSFML_NETWORK_API sfFtpResponse* sfFtp_upload(sfFtp* ftp, const char* localFile, size_t localFileLength, const char* destPath, size_t destPathLength, DInt mode);
 
 //Send a command to the FTP server
 DSFML_NETWORK_API sfFtpResponse* sfFtp_sendCommand(sfFtp* ftp, const char* command, size_t commandLength, const char* parameter, size_t parameterLength);
-
 
 #endif // DSFML_FTP_H

--- a/include/DSFMLC/Network/Http.h
+++ b/include/DSFMLC/Network/Http.h
@@ -1,38 +1,33 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on Laurent Gomila's SFML library.***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_HTTP_H
 #define DSFML_HTTP_H
 
-
-// Headers
 #include <DSFMLC/Network/Export.h>
 #include <DSFMLC/Network/Types.h>
 #include <stddef.h>
@@ -42,73 +37,56 @@ All Libraries used by SFML
 //Create a new HTTP request
 DSFML_NETWORK_API sfHttpRequest* sfHttpRequest_create(void);
 
-
 //Destroy a HTTP request
 DSFML_NETWORK_API void sfHttpRequest_destroy(sfHttpRequest* httpRequest);
-
 
 //Set the value of a header field of a HTTP request
 DSFML_NETWORK_API void sfHttpRequest_setField(sfHttpRequest* httpRequest, const char* field, size_t fieldLength, const char* value, size_t valueLength);
 
-
 //Set a HTTP request method
 DSFML_NETWORK_API void sfHttpRequest_setMethod(sfHttpRequest* httpRequest, DInt method);
-
 
 //Set a HTTP request URI
 DSFML_NETWORK_API void sfHttpRequest_setUri(sfHttpRequest* httpRequest, const char* uri, size_t length);
 
-
 //Set the HTTP version of a HTTP request
 DSFML_NETWORK_API void sfHttpRequest_setHttpVersion(sfHttpRequest* httpRequest, DUint major, DUint minor);
 
-
 //Set the body of a HTTP request
 DSFML_NETWORK_API void sfHttpRequest_setBody(sfHttpRequest* httpRequest, const char* body, size_t length);
-
 
 ///HTTP Response Functions
 
 //Destroy a HTTP response
 DSFML_NETWORK_API void sfHttpResponse_destroy(sfHttpResponse* httpResponse);
 
-
 //Get the value of a field of a HTTP response
 DSFML_NETWORK_API const char* sfHttpResponse_getField(const sfHttpResponse* httpResponse, const char* field, size_t fieldlength);
-
 
 //Get the status code of a HTTP reponse
 DSFML_NETWORK_API DInt sfHttpResponse_getStatus(const sfHttpResponse* httpResponse);
 
-
 //Get the major HTTP version number of a HTTP response
 DSFML_NETWORK_API DUint sfHttpResponse_getMajorVersion(const sfHttpResponse* httpResponse);
-
 
 //Get the minor HTTP version number of a HTTP response
 DSFML_NETWORK_API DUint sfHttpResponse_getMinorVersion(const sfHttpResponse* httpResponse);
 
-
 //Get the body of a HTTP response
 DSFML_NETWORK_API const char* sfHttpResponse_getBody(const sfHttpResponse* httpResponse);
-
 
 ///HTTP Functions
 
 //Create a new Http object
 DSFML_NETWORK_API sfHttp* sfHttp_create(void);
 
-
 //Destroy a Http object
 DSFML_NETWORK_API void sfHttp_destroy(sfHttp* http);
-
 
 //Set the target host of a HTTP object
 DSFML_NETWORK_API void sfHttp_setHost(sfHttp* http, const char* host, size_t length,DUshort port);
 
-
 //Send a HTTP request and return the server's response.
 DSFML_NETWORK_API sfHttpResponse* sfHttp_sendRequest(sfHttp* http, const sfHttpRequest* request, DLong timeout);
-
 
 #endif // DSFML_HTTP_H

--- a/include/DSFMLC/Network/IpAddress.h
+++ b/include/DSFMLC/Network/IpAddress.h
@@ -1,37 +1,34 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on Laurent Gomila's SFML library.***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_IPADDRESS_H
 #define DSFML_IPADDRESS_H
 
-// Headers
+
 #include <DSFMLC/Network/Export.h>
 #include <SFML/Network/IpAddress.hpp>
 #include <stddef.h>
@@ -40,13 +37,10 @@ All Libraries used by SFML
 //Get the host integer representation from a string
 DSFML_NETWORK_API DUint sfIpAddress_integerFromString(const char* address, size_t addressLength);
 
-
 //Get the computer's local address
 DSFML_NETWORK_API void sfIpAddress_getLocalAddress(sf::IpAddress* ipAddress);
 
-
 //Get the computer's public address
 DSFML_NETWORK_API void sfIpAddress_getPublicAddress(sf::IpAddress* ipAddress, DLong timeout);
-
 
 #endif // DSFML_IPADDRESS_H

--- a/include/DSFMLC/Network/Packet.h
+++ b/include/DSFMLC/Network/Packet.h
@@ -1,77 +1,63 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on Laurent Gomila's SFML library.***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_PACKET_H
 #define DSFML_PACKET_H
 
-// Headers
 #include <DSFMLC/Network/Export.h>
 #include <DSFMLC/Network/Types.h>
 #include <stddef.h>
 
-
 //Create a new packet
 DSFML_NETWORK_API sfPacket* sfPacket_create(void);
-
 
 //Create a new packet by copying an existing one
 DSFML_NETWORK_API sfPacket* sfPacket_copy(const sfPacket* packet);
 
-
 //Destroy a packet
 DSFML_NETWORK_API void sfPacket_destroy(sfPacket* packet);
-
 
 //Append data to the end of a packet
 DSFML_NETWORK_API void sfPacket_append(sfPacket* packet, const void* data, size_t sizeInBytes);
 
-
 //Clear a packet
 DSFML_NETWORK_API void sfPacket_clear(sfPacket* packet);
-
 
 //Get a pointer to the data contained in a packet
 DSFML_NETWORK_API const void* sfPacket_getData(const sfPacket* packet);
 
-
 //Get the size of the data contained in a packet
 DSFML_NETWORK_API size_t sfPacket_getDataSize(const sfPacket* packet);
-
 
 //Tell if the reading position has reached the end of a packet
 DSFML_NETWORK_API DBool sfPacket_endOfPacket(const sfPacket* packet);
 
-
 //Test the validity of a packet, for reading
 DSFML_NETWORK_API DBool sfPacket_canRead(const sfPacket* packet);
-
 
 //Functions to extract data from a packet
 DSFML_NETWORK_API DBool    sfPacket_readBool(sfPacket* packet);
@@ -102,6 +88,5 @@ DSFML_NETWORK_API void sfPacket_writeFloat(sfPacket* packet, float);
 DSFML_NETWORK_API void sfPacket_writeDouble(sfPacket* packet, double);
 //DSFML_NETWORK_API void sfPacket_writeString(sfPacket* packet, const char* string);
 //DSFML_NETWORK_API void sfPacket_writeWideString(sfPacket* packet, const wchar_t* string);//Remove in lieu of readUint16 and readUint32 for W and D chars in D?
-
 
 #endif // DSFML_PACKET_H

--- a/include/DSFMLC/Network/SocketSelector.h
+++ b/include/DSFMLC/Network/SocketSelector.h
@@ -1,41 +1,35 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on Laurent Gomila's SFML library.***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_SOCKETSELECTOR_H
 #define DSFML_SOCKETSELECTOR_H
 
-// Headers
 #include <DSFMLC/Network/Export.h>
 #include <DSFMLC/Network/Types.h>
-
-
 
 //Create a new selector
 DSFML_NETWORK_API sfSocketSelector* sfSocketSelector_create(void);
@@ -43,35 +37,28 @@ DSFML_NETWORK_API sfSocketSelector* sfSocketSelector_create(void);
 //Create a new socket selector by copying an existing one
 DSFML_NETWORK_API sfSocketSelector* sfSocketSelector_copy(const sfSocketSelector* selector);
 
-
 //Destroy a socket selector
 DSFML_NETWORK_API void sfSocketSelector_destroy(sfSocketSelector* selector);
-
 
 //Add a new socket to a socket selector
 DSFML_NETWORK_API void sfSocketSelector_addTcpListener(sfSocketSelector* selector, sfTcpListener* socket);
 DSFML_NETWORK_API void sfSocketSelector_addTcpSocket(sfSocketSelector* selector, sfTcpSocket* socket);
 DSFML_NETWORK_API void sfSocketSelector_addUdpSocket(sfSocketSelector* selector, sfUdpSocket* socket);
 
-
 //Remove a socket from a socket selector
 DSFML_NETWORK_API void sfSocketSelector_removeTcpListener(sfSocketSelector* selector, sfTcpListener* socket);
 DSFML_NETWORK_API void sfSocketSelector_removeTcpSocket(sfSocketSelector* selector, sfTcpSocket* socket);
 DSFML_NETWORK_API void sfSocketSelector_removeUdpSocket(sfSocketSelector* selector, sfUdpSocket* socket);
 
-
 //Remove all the sockets stored in a selector
 DSFML_NETWORK_API void sfSocketSelector_clear(sfSocketSelector* selector);
 
-
 //Wait until one or more sockets are ready to receive
 DSFML_NETWORK_API DBool sfSocketSelector_wait(sfSocketSelector* selector, DLong timeout);
-
 
 //Test a socket to know if it is ready to receive data
 DSFML_NETWORK_API DBool sfSocketSelector_isTcpListenerReady(const sfSocketSelector* selector, sfTcpListener* socket);
 DSFML_NETWORK_API DBool sfSocketSelector_isTcpSocketReady(const sfSocketSelector* selector, sfTcpSocket* socket);
 DSFML_NETWORK_API DBool sfSocketSelector_isUdpSocketReady(const sfSocketSelector* selector, sfUdpSocket* socket);
-
 
 #endif // DSFML_SOCKETSELECTOR_H

--- a/include/DSFMLC/Network/TcpListener.h
+++ b/include/DSFMLC/Network/TcpListener.h
@@ -1,69 +1,56 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on Laurent Gomila's SFML library.***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_TCPLISTENER_H
 #define DSFML_TCPLISTENER_H
 
-// Headers
 #include <DSFMLC/Network/Export.h>
 #include <DSFMLC/Network/Types.h>
 #include <SFML/Network/IpAddress.hpp>
 
-
-
 //Create a new TCP listener
 DSFML_NETWORK_API sfTcpListener* sfTcpListener_create(void);
-
 
 //Destroy a TCP listener
 DSFML_NETWORK_API void sfTcpListener_destroy(sfTcpListener* listener);
 
-
 //Set the blocking state of a TCP listener
 DSFML_NETWORK_API void sfTcpListener_setBlocking(sfTcpListener* listener, DBool blocking);
-
 
 //Tell whether a TCP listener is in blocking or non-blocking mode
 DSFML_NETWORK_API DBool sfTcpListener_isBlocking(const sfTcpListener* listener);
 
-
 //Get the port to which a TCP listener is bound locally
 DSFML_NETWORK_API DUshort sfTcpListener_getLocalPort(const sfTcpListener* listener);
-
 
 //Start listening for connections
 DSFML_NETWORK_API DInt sfTcpListener_listen(sfTcpListener* listener, DUshort port, const sf::IpAddress* address);
 
-
 //Accept a new connection
 DSFML_NETWORK_API DInt sfTcpListener_accept(sfTcpListener* listener, sfTcpSocket* connected);
-
 
 #endif // DSFML_TCPLISTENER_H

--- a/include/DSFMLC/Network/TcpSocket.h
+++ b/include/DSFMLC/Network/TcpSocket.h
@@ -1,43 +1,37 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on Laurent Gomila's SFML library.***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_TCPSOCKET_H
 #define DSFML_TCPSOCKET_H
 
-
-// Headers
 #include <DSFMLC/Network/Export.h>
 #include <DSFMLC/Network/IpAddress.h>
 #include <DSFMLC/Network/Types.h>
 #include <stddef.h>
-
 
 //Destroy internal stored data for receiving
 DSFML_NETWORK_API void sfTcpSocket_destroyInternalData(void);
@@ -45,53 +39,40 @@ DSFML_NETWORK_API void sfTcpSocket_destroyInternalData(void);
 //Create a new TCP socket
 DSFML_NETWORK_API sfTcpSocket* sfTcpSocket_create(void);
 
-
 //Destroy a TCP socket
 DSFML_NETWORK_API void sfTcpSocket_destroy(sfTcpSocket* socket);
-
 
 //Set the blocking state of a TCP listener
 DSFML_NETWORK_API void sfTcpSocket_setBlocking(sfTcpSocket* socket, DBool blocking);
 
-
 //Tell whether a TCP socket is in blocking or non-blocking mode
 DSFML_NETWORK_API DBool sfTcpSocket_isBlocking(const sfTcpSocket* socket);
-
 
 //Get the port to which a TCP socket is bound locally
 DSFML_NETWORK_API DUshort sfTcpSocket_getLocalPort(const sfTcpSocket* socket);
 
-
 //Get the address of the connected peer of a TCP socket
 DSFML_NETWORK_API void sfTcpSocket_getRemoteAddress(const sfTcpSocket* socket, sf::IpAddress* ipAddress);
-
 
 //Get the port of the connected peer to which a TCP socket is connected
 DSFML_NETWORK_API DUshort sfTcpSocket_getRemotePort(const sfTcpSocket* socket);
 
-
 //Connect a TCP socket to a remote peer
 DSFML_NETWORK_API DInt sfTcpSocket_connect(sfTcpSocket* socket, const sf::IpAddress* ipAddress, DUshort port, DLong timeout);
-
 
 //Disconnect a TCP socket from its remote peer
 DSFML_NETWORK_API void sfTcpSocket_disconnect(sfTcpSocket* socket);
 
-
 //Send raw data to the remote peer of a TCP socket
 DSFML_NETWORK_API DInt sfTcpSocket_send(sfTcpSocket* socket, const void* data, size_t size);
-
 
 //Receive raw data from the remote peer of a TCP socket
 DSFML_NETWORK_API DInt sfTcpSocket_receive(sfTcpSocket* socket, void* data, size_t maxSize, size_t* sizeReceived);
 
-
 //Send a formatted packet of data to the remote peer of a TCP socket
 DSFML_NETWORK_API DInt sfTcpSocket_sendPacket(sfTcpSocket* socket, sfPacket* packet);
 
-
 //Receive a formatted packet of data from the remote peer
 DSFML_NETWORK_API DInt sfTcpSocket_receivePacket(sfTcpSocket* socket, sfPacket* packet);
-
 
 #endif // DSFML_TCPSOCKET_H

--- a/include/DSFMLC/Network/Types.h
+++ b/include/DSFMLC/Network/Types.h
@@ -1,30 +1,32 @@
-////////////////////////////////////////////////////////////
-//
-// SFML - Simple and Fast Multimedia Library
-// Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-//
-// This software is provided 'as-is', without any express or implied warranty.
-// In no event will the authors be held liable for any damages arising from the use of this software.
-//
-// Permission is granted to anyone to use this software for any purpose,
-// including commercial applications, and to alter it and redistribute it freely,
-// subject to the following restrictions:
-//
-// 1. The origin of this software must not be misrepresented;
-//    you must not claim that you wrote the original software.
-//    If you use this software in a product, an acknowledgment
-//    in the product documentation would be appreciated but is not required.
-//
-// 2. Altered source versions must be plainly marked as such,
-//    and must not be misrepresented as being the original software.
-//
-// 3. This notice may not be removed or altered from any source distribution.
-//
-////////////////////////////////////////////////////////////
+/*
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef SFML_NETWORK_TYPES_H
 #define SFML_NETWORK_TYPES_H
-
 
 typedef struct sfFtpDirectoryResponse sfFtpDirectoryResponse;
 typedef struct sfFtpListingResponse sfFtpListingResponse;

--- a/include/DSFMLC/Network/UdpSocket.h
+++ b/include/DSFMLC/Network/UdpSocket.h
@@ -1,89 +1,72 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on Laurent Gomila's SFML library.***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_UDPSOCKET_H
 #define DSFML_UDPSOCKET_H
 
-// Headers
 #include <DSFMLC/Network/Export.h>
 #include <DSFMLC/Network/IpAddress.h>
 #include <DSFMLC/Network/Types.h>
 #include <stddef.h>
 
-
 //Destroy internal stored data for receiving
 DSFML_NETWORK_API void sfUdpSocket_destroyInternalData(void);
-
 
 //Create a new UDP socket
 DSFML_NETWORK_API sfUdpSocket* sfUdpSocket_create(void);
 
-
 //Destroy a UDP socket
 DSFML_NETWORK_API void sfUdpSocket_destroy(sfUdpSocket* socket);
-
 
 //Set the blocking state of a UDP listener
 DSFML_NETWORK_API void sfUdpSocket_setBlocking(sfUdpSocket* socket, DBool blocking);
 
-
 //Tell whether a UDP socket is in blocking or non-blocking mode
 DSFML_NETWORK_API DBool sfUdpSocket_isBlocking(const sfUdpSocket* socket);
-
 
 //Get the port to which a UDP socket is bound locally
 DSFML_NETWORK_API DUshort sfUdpSocket_getLocalPort(const sfUdpSocket* socket);
 
-
 //Bind a UDP socket to a specific port
 DSFML_NETWORK_API DInt sfUdpSocket_bind(sfUdpSocket* socket, DUshort port, sf::IpAddress* ipAddress);
-
 
 //Unbind a UDP socket from the local port to which it is bound
 DSFML_NETWORK_API void sfUdpSocket_unbind(sfUdpSocket* socket);
 
-
 //Send raw data to a remote peer with a UDP socket
 DSFML_NETWORK_API DInt sfUdpSocket_send(sfUdpSocket* socket, const void* data, size_t size, sf::IpAddress* receiver, DUshort port);
-
 
 //Receive raw data from a remote peer with a UDP socket
 DSFML_NETWORK_API DInt sfUdpSocket_receive(sfUdpSocket* socket, void* data, size_t maxSize, size_t* sizeReceived, sf::IpAddress* sender, DUshort* port);
 
-
 //Send a formatted packet of data to a remote peer with a UDP socket
 DSFML_NETWORK_API DInt sfUdpSocket_sendPacket(sfUdpSocket* socket, sfPacket* packet, sf::IpAddress* receiver, DUshort port);
 
-
 //Receive a formatted packet of data from a remote peer with a UDP socket
 DSFML_NETWORK_API DInt sfUdpSocket_receivePacket(sfUdpSocket* socket, sfPacket* packet, sf::IpAddress* sender, DUshort* port);
-
 
 #endif // SFML_UDPSOCKET_H

--- a/include/DSFMLC/System/DStream.hpp
+++ b/include/DSFMLC/System/DStream.hpp
@@ -1,32 +1,29 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 
 #ifndef DSFML_DSTREAM_H
@@ -35,7 +32,7 @@ All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license
 #include <DSFMLC/Config.h>
 #include <SFML/System.hpp>
 
-//Define an interface that D actually likes to work with
+//Define an interface usable with D's C++ interop
 class DStream
 {
 public:
@@ -55,13 +52,14 @@ class sfmlStream:public sf::InputStream
 
 private:
     DStream* myStream;
-    
+
 public:
 
     sfmlStream()
     {
 
     }
+
     sfmlStream(DStream* stream)
     {
         myStream = stream;
@@ -88,6 +86,5 @@ public:
     }
 
 };
-
 
 #endif // DSFML_DSTREAM_H

--- a/include/DSFMLC/System/Err.h
+++ b/include/DSFMLC/System/Err.h
@@ -1,37 +1,33 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_ERR_H
 #define DSFML_ERR_H
 
-//Headers
 #include <DSFMLC/System/Export.h>
 
 //Redirect sf::err() so that its output can be gotten later

--- a/include/DSFMLC/System/Export.h
+++ b/include/DSFMLC/System/Export.h
@@ -1,48 +1,35 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_SYSTEM_EXPORT_H
 #define DSFML_SYSTEM_EXPORT_H
 
-//Headers
 #include <DSFMLC/Config.h>
 
-//If we define DSFML_SYSTEM_EXPORTS
-#if defined(DSFML_SYSTEM_EXPORTS)
-	//We need to make sure the SFML_SYSTEM_EXPORTS is defined as well
-	//#define SFML_SYSTEM_EXPORTS 
-#endif
-
-//Then we define out D export. Will work for shared and static builds (since for static SFML_API_EXPORT is just empty)
 #define DSFML_SYSTEM_API extern "C" SFML_API_EXPORT
-
-
 
 #endif // DSFML_SYSTEM_EXPORT_H

--- a/include/DSFMLC/System/String.h
+++ b/include/DSFMLC/System/String.h
@@ -1,37 +1,33 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_STRING_H
 #define DSFML_STRING_H
 
-//Headers
 #include <DSFMLC/System/Export.h>
 #include <stddef.h>
 
@@ -46,7 +42,5 @@ DSFML_SYSTEM_API void utf32to16(const DUint* inStr, size_t inLen, const DUshort*
 //Convert to utf32
 DSFML_SYSTEM_API void utf8to32(const DUbyte* inStr, size_t inLen, const DUint* outStr, size_t* outLen);
 DSFML_SYSTEM_API void utf16to32(const DUshort* inStr, size_t inLen, const DUint* outStr, size_t* outLen);
-
-
 
 #endif//DSFML_STRING_H

--- a/include/DSFMLC/System/Threads.h
+++ b/include/DSFMLC/System/Threads.h
@@ -1,40 +1,36 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
 #ifndef DSFML_THREADS_H
 #define DSFML_THREADS_H
 
-//Headers
 #include <DSFMLC/System/Export.h>
 
 //call XInitThreads
 DSFML_SYSTEM_API void linux_XInitThreads(void);
-
 
 #endif // DSFML_THREADS_H

--- a/include/DSFMLC/Window/Context.h
+++ b/include/DSFMLC/Window/Context.h
@@ -1,53 +1,43 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_CONTEXT_H
 #define DSFML_CONTEXT_H
 
-
-// Headers
 #include <DSFMLC/Window/Export.h>
 #include <DSFMLC/Window/Types.h>
-
-
 
 //Create a new context
 DSFML_WINDOW_API sfContext* sfContext_create(void);
 
-
 //Destroy a context
 DSFML_WINDOW_API void sfContext_destroy(sfContext* context);
 
-
 //Activate or deactivate explicitely a context
 DSFML_WINDOW_API void sfContext_setActive(sfContext* context, DBool active);
-
 
 #endif // DSFML_CONTEXT_H

--- a/include/DSFMLC/Window/Err.h
+++ b/include/DSFMLC/Window/Err.h
@@ -1,37 +1,33 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_ERR_H
 #define DSFML_ERR_H
 
-//Headers
 #include <DSFMLC/Window/Export.h>
 
 //Redirect sf::err() so that its output can be gotten later

--- a/include/DSFMLC/Window/Event.h
+++ b/include/DSFMLC/Window/Event.h
@@ -1,42 +1,37 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_EVENT_H
 #define DSFML_EVENT_H
 
-// Headers
 #include <DSFMLC/Window/Export.h>
 #include <DSFMLC/Window/Joystick.h>
 #include <DSFMLC/Window/Keyboard.h>
 #include <DSFMLC/Window/Mouse.h>
-
 
 struct DEvent
 {
@@ -169,8 +164,5 @@ enum EventType
 
 	};
 };
-
-
-
 
 #endif // DSFML_EVENT_H

--- a/include/DSFMLC/Window/Export.h
+++ b/include/DSFMLC/Window/Export.h
@@ -1,49 +1,35 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef SFML_WINDOW_EXPORT_H
 #define SFML_WINDOW_EXPORT_H
 
-// Headers
 #include <DSFMLC/Config.h>
 
-
-//If we define DSFML_WINDOW_EXPORTS
-#if defined(DSFML_WINDOW_EXPORTS)
-	//We need to make sure the SFML_WINDOW_EXPORTS is defined as well
-	
-#endif
-
-//Then we define out D export. Will work for shared and static builds (since for static SFML_API_EXPORT is just empty)
 #define DSFML_WINDOW_API extern "C" SFML_API_EXPORT
-
-
 
 #endif // SFML_WINDOW_EXPORT_H

--- a/include/DSFMLC/Window/Joystick.h
+++ b/include/DSFMLC/Window/Joystick.h
@@ -1,41 +1,35 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_JOYSTICK_H
 #define DSFML_JOYSTICK_H
 
-
-// Headers
 #include <DSFMLC/Window/Export.h>
 #include <stddef.h>
-
 
 //Global joysticks capabilities
 enum
@@ -44,8 +38,6 @@ enum
     sfJoystickButtonCount = 32, /// Maximum number of supported buttons
     sfJoystickAxisCount   = 8   /// Maximum number of supported axes
 };
-
-
 
 //Axes supported by SFML joysticks
 typedef enum
@@ -60,23 +52,17 @@ typedef enum
     sfJoystickPovY  /// The Y axis of the point-of-view hat
 } sfJoystickAxis;
 
-
-
 //Check if a joystick is connected
 DSFML_WINDOW_API DBool sfJoystick_isConnected(DUint joystick);
-
 
 //Return the number of buttons supported by a joystick
 DSFML_WINDOW_API DUint sfJoystick_getButtonCount(DUint joystick);
 
-
 //Check if a joystick supports a given axis
 DSFML_WINDOW_API DBool sfJoystick_hasAxis(DUint joystick, DInt axis);
 
-
 //Check if a joystick button is pressed
 DSFML_WINDOW_API DBool sfJoystick_isButtonPressed(DUint joystick, DUint button);
-
 
 //Get the current position of a joystick axis
 DSFML_WINDOW_API float sfJoystick_getAxisPosition(DUint joystick, DInt axis);
@@ -92,6 +78,5 @@ DSFML_WINDOW_API void sfJoystick_getIdentification(DUint joystick, DUint * vendo
 
 //Update the states of all joysticks
 DSFML_WINDOW_API void sfJoystick_update(void);
-
 
 #endif // SFML_JOYSTICK_H

--- a/include/DSFMLC/Window/Keyboard.h
+++ b/include/DSFMLC/Window/Keyboard.h
@@ -1,43 +1,36 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_KEYBOARD_H
 #define DSFML_KEYBOARD_H
 
-
-// Headers
 #include <DSFMLC/Window/Export.h>
-
 
 //Check if a key is pressed
 DSFML_WINDOW_API DBool sfKeyboard_isKeyPressed(DInt key);
-
 
 #endif // DSFML_KEYBOARD_H

--- a/include/DSFMLC/Window/Mouse.h
+++ b/include/DSFMLC/Window/Mouse.h
@@ -1,57 +1,44 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef SFML_MOUSE_H
 #define SFML_MOUSE_H
 
 
-// Headers
 #include <DSFMLC/Window/Export.h>
 #include <DSFMLC/Window/Types.h>
-
-
-
-
-
-
 
 //Check if a mouse button is pressed
 DSFML_WINDOW_API DBool sfMouse_isButtonPressed(DInt button);
 
-
 //Get the current position of the mouse
 DSFML_WINDOW_API void sfMouse_getPosition(const sfWindow* relativeTo, DInt* x, DInt* y);
 
-
 //Set the current position of the mouse
 DSFML_WINDOW_API void sfMouse_setPosition(DInt x, DInt y, const sfWindow* relativeTo);
-
 
 #endif // DSFML_MOUSE_H

--- a/include/DSFMLC/Window/Sensor.h
+++ b/include/DSFMLC/Window/Sensor.h
@@ -1,32 +1,29 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef SFML_SENSOR_H
 #define SFML_SENSOR_H
@@ -42,6 +39,5 @@ DSFML_WINDOW_API void sfSensor_setEnabled(DInt sensor, DBool enabled);
 
 //Get the current sensor value
 DSFML_WINDOW_API void sfSensor_getValue(DInt sensor, float* x, float* y, float* z);
-
 
 #endif /* SFML_SENSOR_H */

--- a/include/DSFMLC/Window/Touch.h
+++ b/include/DSFMLC/Window/Touch.h
@@ -1,32 +1,29 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef SFML_TOUCH_H
 #define SFML_TOUCH_H

--- a/include/DSFMLC/Window/Types.h
+++ b/include/DSFMLC/Window/Types.h
@@ -1,39 +1,34 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_WINDOW_TYPES_H
 #define DSFML_WINDOW_TYPES_H
 
-
 typedef struct sfContext sfContext;
 typedef struct sfWindow sfWindow;
-
 
 #endif // DSFML_WINDOW_TYPES_H

--- a/include/DSFMLC/Window/VideoMode.h
+++ b/include/DSFMLC/Window/VideoMode.h
@@ -1,52 +1,43 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_VIDEOMODE_H
 #define DSFML_VIDEOMODE_H
 
-
-// Headers
 #include <DSFMLC/Window/Export.h>
 #include <stddef.h>
-
 
 //Get the current desktop video mode
 DSFML_WINDOW_API void sfVideoMode_getDesktopMode(DUint* width, DUint* height, DUint* bitsPerPixel);
 
-
 //Retrieve all the video modes supported in fullscreen mode
 DSFML_WINDOW_API const DUint* sfVideoMode_getFullscreenModes(size_t* Count);
 
-
 //Tell whether or not a video mode is valid
 DSFML_WINDOW_API DBool sfVideoMode_isValid(DUint width, DUint height, DUint bitsPerPixel);
-
 
 #endif // DSFML_VIDEOMODE_H

--- a/include/DSFMLC/Window/Window.h
+++ b/include/DSFMLC/Window/Window.h
@@ -1,38 +1,33 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_WINDOW_H
 #define DSFML_WINDOW_H
 
-
-// Headers
 #include <DSFMLC/Window/Export.h>
 #include <DSFMLC/Window/Event.h>
 #include <DSFMLC/Window/WindowHandle.h>
@@ -42,86 +37,65 @@ All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license
 //Construct a new window
 DSFML_WINDOW_API sfWindow* sfWindow_construct(void);
 
-
 //Construct a new window from settings
 DSFML_WINDOW_API void sfWindow_createFromSettings(sfWindow* window, DUint width, DUint height, DUint bitsPerPixel, const DUint* title, size_t titleLength, DInt style, DUint depthBits, DUint stencilBits, DUint antialiasingLevel, DUint majorVersion, DUint minorVersion);
-
 
 //Construct a window from an existing control
 DSFML_WINDOW_API void sfWindow_createFromHandle(sfWindow* window, sfWindowHandle handle, DUint depthBits, DUint stencilBits, DUint antialiasingLevel, DUint majorVersion, DUint minorVersion);
 
-
 // Destroy a window
 DSFML_WINDOW_API void sfWindow_destroy(sfWindow* window);
-
 
 //Close a window and destroy all the attached resources
 DSFML_WINDOW_API void sfWindow_close(sfWindow* window);
 
-
 //Tell whether or not a window is opened
 DSFML_WINDOW_API DBool sfWindow_isOpen(const sfWindow* window);
-
 
 //Get the settings of the OpenGL context of a window
 DSFML_WINDOW_API void sfWindow_getSettings(const sfWindow* window, DUint* depthBits, DUint* stencilBits, DUint* antialiasingLevel, DUint* majorVersion, DUint* minorVersion);
 
-
 //Pop the event on top of event queue, if any, and return it
 DSFML_WINDOW_API DBool sfWindow_pollEvent(sfWindow* window, DEvent* event);
-
 
 //Wait for an event and return it
 DSFML_WINDOW_API DBool sfWindow_waitEvent(sfWindow* window, DEvent* event);
 
-
 //Get the position of a window
 DSFML_WINDOW_API void sfWindow_getPosition(const sfWindow* window, DInt* x, DInt* y);
-
 
 //Change the position of a window on screen
 DSFML_WINDOW_API void sfWindow_setPosition(sfWindow* window, DInt x, DInt y);
 
-
 //Get the size of the rendering region of a window
 DSFML_WINDOW_API void sfWindow_getSize(const sfWindow* window, DUint* width, DUint* height);
-
 
 //Change the size of the rendering region of a window
 DSFML_WINDOW_API void sfWindow_setSize(sfWindow* window, DUint width, DUint height);
 
-
 //Change the title of a window
 DSFML_WINDOW_API void sfWindow_setTitle(sfWindow* window, const char* title, size_t length);
-
 
 //Change the title of a window (with a UTF-32 string)
 DSFML_WINDOW_API void sfWindow_setUnicodeTitle(sfWindow* window, const DUint* title, size_t length);
 
-
 //Change a window's icon
 DSFML_WINDOW_API void sfWindow_setIcon(sfWindow* window, DUint width, DUint height, const DUbyte* pixels);
-
 
 //Show or hide a window
 DSFML_WINDOW_API void sfWindow_setVisible(sfWindow* window, DBool visible);
 
-
 //Show or hide the mouse cursor
 DSFML_WINDOW_API void sfWindow_setMouseCursorVisible(sfWindow* window, DBool visible);
-
 
 //Enable or disable vertical synchronization
 DSFML_WINDOW_API void sfWindow_setVerticalSyncEnabled(sfWindow* window, DBool enabled);
 
-
 //Enable or disable automatic key-repeat
 DSFML_WINDOW_API void sfWindow_setKeyRepeatEnabled(sfWindow* window, DBool enabled);
 
-
 //Activate or deactivate a window as the current target for OpenGL rendering
 DSFML_WINDOW_API DBool sfWindow_setActive(sfWindow* window, DBool active);
-
 
 //Display on screen what has been rendered to the window so far
 DSFML_WINDOW_API void sfWindow_display(sfWindow* window);
@@ -135,13 +109,10 @@ DSFML_WINDOW_API DBool sfWindow_hasFocus(const sfWindow *);
 //Limit the framerate to a maximum fixed frequency
 DSFML_WINDOW_API void sfWindow_setFramerateLimit(sfWindow* window, DUint limit);
 
-
 //Change the joystick threshold
 DSFML_WINDOW_API void sfWindow_setJoystickThreshold(sfWindow* window, float threshold);
 
-
 //Get the OS-specific handle of the window
 DSFML_WINDOW_API sfWindowHandle sfWindow_getSystemHandle(const sfWindow* window);
-
 
 #endif // DSFML_WINDOW_H

--- a/include/DSFMLC/Window/WindowHandle.h
+++ b/include/DSFMLC/Window/WindowHandle.h
@@ -1,37 +1,33 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_WINDOWHANDLE_H
 #define DSFML_WINDOWHANDLE_H
 
-// Headers
 #include <DSFMLC/Window/Export.h>
 
 
@@ -56,6 +52,5 @@ All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license
 	typedef void* sfWindowHandle;
 
 #endif
-
 
 #endif // DSFML_WINDOWHANDLE_H

--- a/src/DSFMLC/Audio/Err.cpp
+++ b/src/DSFMLC/Audio/Err.cpp
@@ -1,53 +1,49 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
-
-//Headers
 #include <DSFMLC/Audio/Err.h>
 #include <SFML/System/Err.hpp>
 #include <sstream>
 #include <string>
 
-
 namespace
 {
-    std::ostringstream outputStream;//stream sf::err() get's redirected to
-    std::string outputString;//string for storing output
-}
+    //stream sf::err() get's redirected to
+    std::ostringstream outputStream;
 
+    //string for storing output
+    std::string outputString;
+}
 
 void sfErrAudio_redirect(void)
 {
     //redirect sf::err() to write to outputStream
     sf::err().rdbuf(outputStream.rdbuf());
 }
-
 
 const char* sfErrAudio_getOutput(void)
 {
@@ -59,4 +55,3 @@ const char* sfErrAudio_getOutput(void)
 
     return outputString.c_str();
 }
-

--- a/src/DSFMLC/Audio/InputSoundFile.cpp
+++ b/src/DSFMLC/Audio/InputSoundFile.cpp
@@ -1,34 +1,30 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
-
-//Headers
 #include <DSFMLC/Audio/InputSoundFile.h>
 #include <SFML/System/InputStream.hpp>
 #include <SFML/System/Lock.hpp>

--- a/src/DSFMLC/Audio/InputSoundFileStruct.h
+++ b/src/DSFMLC/Audio/InputSoundFileStruct.h
@@ -1,41 +1,36 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_INPUTSOUNDFILESTRUCT_H
 #define DSFML_INPUTSOUNDFILESTRUCT_H
 
 
-//Headers
 #include <SFML/Audio/InputSoundFile.hpp>
 #include <DSFMLC/System/DStream.hpp>
-
 
 //Create a wrapper around a sf::priv::SoundFile
 struct sfInputSoundFile
@@ -43,6 +38,5 @@ struct sfInputSoundFile
     sf::InputSoundFile This;
     sfmlStream stream;
 };
-
 
 #endif // DSFML_INPUTSOUNDFILESTRUCT_H

--- a/src/DSFMLC/Audio/InternalSoundRecorder.cpp
+++ b/src/DSFMLC/Audio/InternalSoundRecorder.cpp
@@ -1,34 +1,30 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
-
-//Headers
 #include <DSFMLC/Audio/InternalSoundRecorder.hpp>
 #include <SFML/Audio/AudioDevice.hpp>
 #include <SFML/System/Err.hpp>

--- a/src/DSFMLC/Audio/Listener.cpp
+++ b/src/DSFMLC/Audio/Listener.cpp
@@ -1,34 +1,30 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
-
-//Headers
 #include <DSFMLC/Audio/Listener.h>
 #include <SFML/Audio/Listener.hpp>
 #include <SFML/System/Vector3.hpp>
@@ -38,19 +34,16 @@ void sfListener_setGlobalVolume(float volume)
     sf::Listener::setGlobalVolume(volume);
 }
 
-
 float sfListener_getGlobalVolume(void)
 {
     return sf::Listener::getGlobalVolume();
 }
-
 
 void sfListener_setPosition(float x, float y, float z)
 {
 
     sf::Listener::setPosition(x,y,z);
 }
-
 
 void sfListener_getPosition(float* x, float* y, float* z)
 {
@@ -63,12 +56,10 @@ void sfListener_getPosition(float* x, float* y, float* z)
     *z = temp.z;
 }
 
-
 void sfListener_setDirection(float x, float y, float z)
 {
     sf::Listener::setDirection(x,y,z);
 }
-
 
 void sfListener_getDirection(float* x, float* y, float* z)
 {
@@ -85,7 +76,6 @@ void sfListener_setUpVector(float x, float y, float z)
 {
     sf::Listener::setUpVector(x,y,z);
 }
-
 
 void sfListener_getUpVector(float* x, float* y, float* z)
 {

--- a/src/DSFMLC/Audio/OutputSoundFile.cpp
+++ b/src/DSFMLC/Audio/OutputSoundFile.cpp
@@ -1,34 +1,30 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
-
-//Headers
 #include <DSFMLC/Audio/OutputSoundFile.h>
 #include "OutputSoundFileStruct.h"
 

--- a/src/DSFMLC/Audio/OutputSoundFileStruct.h
+++ b/src/DSFMLC/Audio/OutputSoundFileStruct.h
@@ -1,46 +1,39 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_OUTPUTSOUNDFILESTRUCT_H
 #define DSFML_OUTPUTSOUNDFILESTRUCT_H
 
-
-//Headers
 #include <SFML/Audio/OutputSoundFile.hpp>
-
 
 //Create a wrapper around a sf::OutputSoundFile
 struct sfOutputSoundFile
 {
     sf::OutputSoundFile This;
 };
-
 
 #endif // DSFML_INPUTSOUNDFILESTRUCT_H

--- a/src/DSFMLC/Audio/Sound.cpp
+++ b/src/DSFMLC/Audio/Sound.cpp
@@ -1,32 +1,29 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 //Headers
 #include <DSFMLC/Audio/Sound.h>

--- a/src/DSFMLC/Audio/SoundBuffer.cpp
+++ b/src/DSFMLC/Audio/SoundBuffer.cpp
@@ -1,34 +1,30 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
-
-//Headers
 #include <DSFMLC/Audio/SoundBuffer.h>
 #include "SoundBufferStruct.h"
 

--- a/src/DSFMLC/Audio/SoundBufferStruct.h
+++ b/src/DSFMLC/Audio/SoundBufferStruct.h
@@ -1,3 +1,30 @@
+/*
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
+
 #ifndef DSFML_SOUNDBUFFERSTRUCT_H
 #define DSFML_SOUNDBUFFERSTRUCT_H
 
@@ -7,6 +34,5 @@ struct sfSoundBuffer
 {
 	sf::SoundBuffer This;
 };
-
 
 #endif //DSFML_SOUNDSTRUCT_H

--- a/src/DSFMLC/Audio/SoundRecorder.cpp
+++ b/src/DSFMLC/Audio/SoundRecorder.cpp
@@ -1,37 +1,32 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
-
-//Headers
 #include <DSFMLC/Audio/SoundRecorder.h>
 #include "SoundRecorderStruct.h"
-
 
 sfSoundRecorder* sfSoundRecorder_construct(SoundRecorderCallBacks* newCallBacks)
 {

--- a/src/DSFMLC/Audio/SoundRecorderStruct.h
+++ b/src/DSFMLC/Audio/SoundRecorderStruct.h
@@ -1,42 +1,36 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_SOUNDRECORDER_STRUCT_H
 #define DSFML_SOUNDRECORDER_STRUCT_H
 
-//Headers
 #include <SFML/Audio/SoundRecorder.hpp>
 #include <SFML/System/Time.hpp>
 #include <DSFMLC/Config.h>
-
-
 
 //class to use in D
 class SoundRecorderCallBacks
@@ -62,7 +56,7 @@ public:
 		//callBacks = newCallBacks;
 	}
 
-	//XXX Using a public method here to gain access to a C++ Protected method from D. Not sure if this is the best way.
+	// Using a public method here to gain access to a C++ Protected method from D. Not sure if this is the best way.
 	void setProcessingIntervalD (DUlong time)
 	{
 		sf::SoundRecorder::setProcessingInterval(sf::microseconds(time));

--- a/src/DSFMLC/Audio/SoundSource.cpp
+++ b/src/DSFMLC/Audio/SoundSource.cpp
@@ -1,34 +1,30 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
-
-//Headers
 #include <DSFMLC/Audio/SoundSource.h>
 
 void sfSoundSource_ensureALInit()

--- a/src/DSFMLC/Audio/SoundStream.cpp
+++ b/src/DSFMLC/Audio/SoundStream.cpp
@@ -1,40 +1,34 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
-
-//Headers
 #include <DSFMLC/Audio/SoundStream.h>
 #include <SFML/Audio/SoundSource.hpp>
 #include <SFML/System/Time.hpp>
 #include <SFML/System/Vector3.hpp>
-
-
 
 sfSoundStream* sfSoundStream_construct(SoundStreamCallBacks* callBacks)
 {
@@ -48,7 +42,7 @@ void sfSoundStream_destroy(sfSoundStream* soundStream)
 
 void sfSoundStream_initialize(sfSoundStream* soundStream, DUint channelCount, DUint sampleRate)
 {
-    soundStream->This.SoundStreamInitialize(channelCount, sampleRate);    
+    soundStream->This.SoundStreamInitialize(channelCount, sampleRate);
 }
 
 void sfSoundStream_play(sfSoundStream* soundStream)
@@ -138,7 +132,6 @@ void sfSoundStream_getPosition(const sfSoundStream* soundStream, float* position
     *positionX = position.x;
     *positionY = position.y;
     *positionZ = position.z;
-
 }
 
 DBool sfSoundStream_isRelativeToListener(const sfSoundStream* soundStream)

--- a/src/DSFMLC/Audio/SoundStreamStruct.h
+++ b/src/DSFMLC/Audio/SoundStreamStruct.h
@@ -1,39 +1,35 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_SOUNDSTREAMSTRUCT_H
 #define DSFML_SOUNDSTREAMSTRUCT_H
 
 #include <SFML/Audio/SoundStream.hpp>
 #include <DSFMLC/Config.h>
-
 
 struct sfChunk
 {
@@ -51,7 +47,6 @@ public:
 	virtual void onSeek(DLong time);
 };
 
-
 class sfSoundStreamImp : public sf::SoundStream
 {
 
@@ -63,14 +58,13 @@ public:
 	sfSoundStreamImp(SoundStreamCallBacks* newCallBacks)
 	{
 		callBacks = newCallBacks;
-		
+
 	}
-	
+
 	void SoundStreamInitialize(DUint channelCount, DUint sampleRate)
 	{
 	    initialize(channelCount, sampleRate);
 	}
-	
 
 protected:
 	virtual bool onGetData(Chunk& data)
@@ -88,8 +82,6 @@ protected:
 	{
 		callBacks->onSeek(timeOffset.asMicroseconds());
 	}
-
-
 };
 
 struct sfSoundStream
@@ -102,7 +94,4 @@ struct sfSoundStream
 	sfSoundStreamImp This;
 };
 
-
 #endif // DSFML_SOUNDSTREAMSTRUCT_H
-
-

--- a/src/DSFMLC/Audio/SoundStruct.h
+++ b/src/DSFMLC/Audio/SoundStruct.h
@@ -1,3 +1,30 @@
+/*
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
+
 #ifndef DSFML_SOUNDSTRUCT_H
 #define DSFML_SOUNDSTRUCT_H
 
@@ -10,6 +37,5 @@ struct sfSound
 	sf::Sound This;
 	const sfSoundBuffer* Buffer;
 };
-
 
 #endif //DSFML_SOUNDSTRUCT_H

--- a/src/DSFMLC/Graphics/CreateRenderStates.hpp
+++ b/src/DSFMLC/Graphics/CreateRenderStates.hpp
@@ -1,37 +1,33 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_CONVERTRENDERSTATES_H
 #define DSFML_CONVERTRENDERSTATES_H
 
-// Headers
 #include <SFML/Graphics/RenderStates.hpp>
 #include <SFML/Graphics/BlendMode.hpp>
 #include <DSFMLC/Graphics/CreateTransform.hpp>
@@ -53,15 +49,13 @@ inline sf::RenderStates createRenderStates(DInt colorSrcFactor, DInt colorDstFac
     blendMode.alphaSrcFactor = static_cast<sf::BlendMode::Factor>(alphaSrcFactor);
     blendMode.alphaDstFactor = static_cast<sf::BlendMode::Factor>(alphaDstFactor);
     blendMode.alphaEquation = static_cast<sf::BlendMode::Equation>(alphaEquation);
-    
+
     sfmlStates.blendMode = blendMode;
     sfmlStates.transform = createTransform(transform);
     sfmlStates.texture = texture ? texture->This : NULL;
     sfmlStates.shader = shader ? &shader->This : NULL;
-    
 
     return sfmlStates;
 }
-
 
 #endif // DSFML_CONVERTRENDERSTATES_H

--- a/src/DSFMLC/Graphics/CreateTransform.hpp
+++ b/src/DSFMLC/Graphics/CreateTransform.hpp
@@ -1,39 +1,34 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_CONVERTTRANSFORM_H
 #define DSFML_CONVERTTRANSFORM_H
 
-// Headers
 #include <SFML/Graphics/Transform.hpp>
-
 
 // Convert sf::Transform to float array
 inline void createTransform(const sf::Transform& transform, float* converted)
@@ -48,18 +43,15 @@ inline void createTransform(const sf::Transform& transform, float* converted)
     converted[6] = m[3];
     converted[7] = m[7];
     converted[8] = m[15];
-    
 }
-
 
 // Convert float array to sf::Transform
 inline sf::Transform createTransform(const float* transform)
 {
-    
+
     return sf::Transform(transform[0], transform[1], transform[2],
                          transform[3], transform[4], transform[5],
                          transform[6], transform[7], transform[8]);
 }
-
 
 #endif // DSFML_CONVERTTRANSFORM_H

--- a/src/DSFMLC/Graphics/Err.cpp
+++ b/src/DSFMLC/Graphics/Err.cpp
@@ -1,44 +1,42 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
-
-//Headers
 #include <DSFMLC/Graphics/Err.h>
 #include <SFML/System/Err.hpp>
 #include <sstream>
 #include <string>
 
-
 namespace
 {
-    std::ostringstream outputStream;//stream sf::err() get's redirected to
-    std::string outputString;//string for storing output
+    //stream sf::err() get's redirected to
+    std::ostringstream outputStream;
+
+    //string for storing output
+    std::string outputString;
 }
 
 
@@ -59,5 +57,3 @@ const char* sfErrGraphics_getOutput(void)
 
     return outputString.c_str();
 }
-
-

--- a/src/DSFMLC/Graphics/Font.cpp
+++ b/src/DSFMLC/Graphics/Font.cpp
@@ -1,35 +1,30 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
-
-
-// Headers
 #include <DSFMLC/Graphics/Font.h>
 #include <DSFMLC/Graphics/FontStruct.h>
 #include <SFML/System/InputStream.hpp>
@@ -40,7 +35,7 @@ sfFont* sfFont_construct()
     font->fontTexture = new sfTexture;
 
     //Delete the internal texture and set OwnInstance to false
-    //This will allow us to set the sf::Texture vatiable to the address
+    //This will allow us to set the sf::Texture vtable to the address
     //of the one returned by the font without copying it or destroying it.
     delete font->fontTexture->This;
     font->fontTexture->This = 0;
@@ -54,14 +49,10 @@ DBool sfFont_loadFromFile(sfFont* font, const char* filename, size_t length)
     return (font->This.loadFromFile(std::string(filename, length)))?DTrue:DFalse;
 }
 
-
-
 DBool sfFont_loadFromMemory(sfFont* font, const void* data, size_t sizeInBytes)
 {
     return (font->This.loadFromMemory(data, sizeInBytes))?DTrue:DFalse;
 }
-
-
 
 DBool sfFont_loadFromStream(sfFont* font, DStream* stream)
 {
@@ -69,14 +60,10 @@ DBool sfFont_loadFromStream(sfFont* font, DStream* stream)
     return (font->This.loadFromStream(font->Stream))?DTrue:DFalse;
 }
 
-
-
 sfFont* sfFont_copy(const sfFont* font)
 {
     return new sfFont(*font);
 }
-
-
 
 void sfFont_destroy(sfFont* font)
 {
@@ -84,11 +71,8 @@ void sfFont_destroy(sfFont* font)
     delete font;
 }
 
-
-
 void sfFont_getGlyph(const sfFont* font, DUint codePoint, DInt characterSize, DBool bold, float* glyphAdvance, float* glyphBoundsLeft, float* glyphBoundsTop, float* glyphBoundsWidth, float* glyphBoundsHeight, DInt* glyphTextRectLeft, DInt* glyphTextRectTop, DInt* glyphTextRectWidth, DInt* glyphTextRectHeight)
 {
-
     sf::Glyph SFMLGlyph = font->This.getGlyph(codePoint, characterSize, bold == DTrue);
 
     *glyphAdvance           = SFMLGlyph.advance;
@@ -100,24 +84,17 @@ void sfFont_getGlyph(const sfFont* font, DUint codePoint, DInt characterSize, DB
     *glyphTextRectTop       = SFMLGlyph.textureRect.top;
     *glyphTextRectWidth     = SFMLGlyph.textureRect.width;
     *glyphTextRectHeight    = SFMLGlyph.textureRect.height;
-
-
 }
-
-
 
 float sfFont_getKerning(const sfFont* font, DUint first, DUint second, DUint characterSize)
 {
     return font->This.getKerning(first, second, characterSize);
 }
 
-
-
 float sfFont_getLineSpacing(const sfFont* font, DUint characterSize)
 {
     return font->This.getLineSpacing(characterSize);
 }
-
 
 float sfFont_getUnderlinePosition(const sfFont* font, DUint characterSize)
 {
@@ -129,7 +106,6 @@ float sfFont_getUnderlineThickness(const sfFont* font, DUint characterSize)
     return font->This.getUnderlineThickness(characterSize);
 }
 
-
 sfTexture* sfFont_getTexturePtr(const sfFont* font)
 {
     return font->fontTexture;
@@ -137,7 +113,6 @@ sfTexture* sfFont_getTexturePtr(const sfFont* font)
 
 void sfFont_updateTexture(const sfFont* font, DUint characterSize)
 {
-
     //Get the address of the underlying sf::Texture to avoid copying it.
     //This is safe because the underlying sf::Texture is only exposed in const form.
     font->fontTexture->This = const_cast<sf::Texture*>(&(font->This.getTexture(characterSize)));

--- a/src/DSFMLC/Graphics/FontStruct.h
+++ b/src/DSFMLC/Graphics/FontStruct.h
@@ -1,47 +1,43 @@
-////////////////////////////////////////////////////////////
-//
-// SFML - Simple and Fast Multimedia Library
-// Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-//
-// This software is provided 'as-is', without any express or implied warranty.
-// In no event will the authors be held liable for any damages arising from the use of this software.
-//
-// Permission is granted to anyone to use this software for any purpose,
-// including commercial applications, and to alter it and redistribute it freely,
-// subject to the following restrictions:
-//
-// 1. The origin of this software must not be misrepresented;
-//    you must not claim that you wrote the original software.
-//    If you use this software in a product, an acknowledgment
-//    in the product documentation would be appreciated but is not required.
-//
-// 2. Altered source versions must be plainly marked as such,
-//    and must not be misrepresented as being the original software.
-//
-// 3. This notice may not be removed or altered from any source distribution.
-//
-////////////////////////////////////////////////////////////
+/*
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_FONTSTRUCT_H
 #define DSFML_FONTSTRUCT_H
 
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
 #include <SFML/Graphics/Font.hpp>
 #include <DSFMLC/Graphics/TextureStruct.h>
 #include <DSFMLC/System/DStream.hpp>
 
-
-////////////////////////////////////////////////////////////
-// Internal structure of sfFont
-////////////////////////////////////////////////////////////
+//Internal structure of sfFont
 struct sfFont
 {
     sf::Font This;
     mutable sfTexture* fontTexture;
     sfmlStream Stream;
 };
-
 
 #endif // DSFML_FONTSTRUCT_H

--- a/src/DSFMLC/Graphics/Image.cpp
+++ b/src/DSFMLC/Graphics/Image.cpp
@@ -1,34 +1,30 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
-
-// Headers
 #include <DSFMLC/Graphics/Image.h>
 #include <DSFMLC/Graphics/ImageStruct.h>
 
@@ -42,31 +38,26 @@ void sfImage_create(sfImage* image, DUint width, DUint height)
     image->This.create(width, height);
 }
 
-
 void sfImage_createFromColor(sfImage* image, DUint width, DUint height, DUbyte r, DUbyte b, DUbyte g, DUbyte a)
 {
     image->This.create(width, height, sf::Color(r, g, b, a));
 
 }
 
-
 void sfImage_createFromPixels(sfImage* image, DUint width, DUint height, const DUbyte* data)
 {
     image->This.create(width, height, data);
 }
-
 
 DBool sfImage_loadFromFile(sfImage* image, const char* filename, size_t length)
 {
     return image->This.loadFromFile(std::string(filename, length))?DTrue:DFalse;
 }
 
-
 DBool sfImage_loadFromMemory(sfImage* image, const void* data, size_t sizeInBytes)
 {
     return image->This.loadFromMemory(data, sizeInBytes)?DTrue:DFalse;
 }
-
 
 DBool sfImage_loadFromStream(sfImage* image, DStream* stream)
 {
@@ -75,31 +66,25 @@ DBool sfImage_loadFromStream(sfImage* image, DStream* stream)
     return image->This.loadFromStream(Stream)?DTrue:DFalse;
 }
 
-
 sfImage* sfImage_copy(const sfImage* image)
 {
-
     return new sfImage(*image);
 }
-
 
 void sfImage_destroy(sfImage* image)
 {
     delete image;
 }
 
-
 DBool sfImage_saveToFile(const sfImage* image, const char* filename, size_t length)
 {
     return image->This.saveToFile(std::string(filename, length))?DTrue:DFalse;
 }
 
-
 void sfImage_createMaskFromColor(sfImage* image, DUbyte r, DUbyte b, DUbyte g, DUbyte a, DUbyte alpha)
 {
     image->This.createMaskFromColor(sf::Color(r, g, b, a), alpha);
 }
-
 
 void sfImage_copyImage(sfImage* image, const sfImage* source, DUint destX, DUint destY, DInt sourceRectTop, DInt sourceRectLeft, DInt sourceRectWidth, DInt sourceRectHeight, DBool applyAlpha)
 {
@@ -107,12 +92,10 @@ void sfImage_copyImage(sfImage* image, const sfImage* source, DUint destX, DUint
     image->This. copy(source->This, destX, destY, sfmlRect, applyAlpha == DTrue);
 }
 
-
 void sfImage_setPixel(sfImage* image, DUint x, DUint y, DUbyte r, DUbyte b, DUbyte g, DUbyte a)
 {
     image->This.setPixel(x, y, sf::Color(r, g, b, a));
 }
-
 
 void sfImage_getPixel(const sfImage* image, DUint x, DUint y, DUbyte* r, DUbyte* b, DUbyte* g, DUbyte* a)
 {
@@ -122,15 +105,12 @@ void sfImage_getPixel(const sfImage* image, DUint x, DUint y, DUbyte* r, DUbyte*
     *b = sfmlColor.b;
     *g = sfmlColor.g;
     *a = sfmlColor.a;
-
 }
-
 
 const DUbyte* sfImage_getPixelsPtr(const sfImage* image)
 {
     return image->This.getPixelsPtr();
 }
-
 
 void sfImage_getSize(const sfImage* image, DUint* width, DUint* height)
 {
@@ -138,15 +118,12 @@ void sfImage_getSize(const sfImage* image, DUint* width, DUint* height)
 
     *width = sfmlSize.x;
     *height = sfmlSize.y;
-
 }
-
 
 void sfImage_flipHorizontally(sfImage* image)
 {
     image->This.flipHorizontally();
 }
-
 
 void sfImage_flipVertically(sfImage* image)
 {

--- a/src/DSFMLC/Graphics/ImageStruct.h
+++ b/src/DSFMLC/Graphics/ImageStruct.h
@@ -1,43 +1,39 @@
-////////////////////////////////////////////////////////////
-//
-// SFML - Simple and Fast Multimedia Library
-// Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-//
-// This software is provided 'as-is', without any express or implied warranty.
-// In no event will the authors be held liable for any damages arising from the use of this software.
-//
-// Permission is granted to anyone to use this software for any purpose,
-// including commercial applications, and to alter it and redistribute it freely,
-// subject to the following restrictions:
-//
-// 1. The origin of this software must not be misrepresented;
-//    you must not claim that you wrote the original software.
-//    If you use this software in a product, an acknowledgment
-//    in the product documentation would be appreciated but is not required.
-//
-// 2. Altered source versions must be plainly marked as such,
-//    and must not be misrepresented as being the original software.
-//
-// 3. This notice may not be removed or altered from any source distribution.
-//
-////////////////////////////////////////////////////////////
+/*
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_IMAGESTRUCT_H
 #define DSFML_IMAGESTRUCT_H
 
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
 #include <SFML/Graphics/Image.hpp>
 
-
-////////////////////////////////////////////////////////////
-// Internal structure of sfImage
-////////////////////////////////////////////////////////////
+//Internal structure of sfImage
 struct sfImage
 {
     sf::Image This;
 };
-
 
 #endif // SFML_IMAGESTRUCT_H

--- a/src/DSFMLC/Graphics/RenderTexture.cpp
+++ b/src/DSFMLC/Graphics/RenderTexture.cpp
@@ -28,7 +28,6 @@ Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
 All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
 */
 
-// Headers
 #include <DSFMLC/Graphics/RenderTexture.h>
 #include <DSFMLC/Graphics/RenderTextureStruct.h>
 #include <DSFMLC/Graphics/CreateRenderStates.hpp>
@@ -40,17 +39,13 @@ sfRenderTexture* sfRenderTexture_construct(void)
 
 void sfRenderTexture_create(sfRenderTexture* renderTexture, DUint width, DUint height, DBool depthBuffer)
 {
-
     renderTexture->This.create(width, height, depthBuffer == DTrue);
-    //renderTexture->Target = new sfTexture(const_cast<sf::Texture*>(&renderTexture->This.getTexture()));
 }
-
 
 void sfRenderTexture_destroy(sfRenderTexture* renderTexture)
 {
     delete renderTexture;
 }
-
 
 void sfRenderTexture_getSize(const sfRenderTexture* renderTexture, DUint* x, DUint* y)
 {
@@ -59,18 +54,15 @@ void sfRenderTexture_getSize(const sfRenderTexture* renderTexture, DUint* x, DUi
     *y = sfmlSize.y;
 }
 
-
 DBool sfRenderTexture_setActive(sfRenderTexture* renderTexture, DBool active)
 {
     return renderTexture->This.setActive(active == DTrue)?DTrue: DFalse;
 }
 
-
 void sfRenderTexture_display(sfRenderTexture* renderTexture)
 {
     renderTexture->This.display();
 }
-
 
 void sfRenderTexture_clear(sfRenderTexture* renderTexture, DUbyte r, DUbyte g, DUbyte b, DUbyte a)
 {
@@ -78,7 +70,6 @@ void sfRenderTexture_clear(sfRenderTexture* renderTexture, DUbyte r, DUbyte g, D
 
     renderTexture->This.clear(SFMLColor);
 }
-
 
 void sfRenderTexture_setView(sfRenderTexture* renderTexture, float centerX, float centerY, float sizeX,
 		float sizeY, float rotation, float viewportLeft, float viewportTop, float viewportWidth,
@@ -91,7 +82,6 @@ void sfRenderTexture_setView(sfRenderTexture* renderTexture, float centerX, floa
 	view.setViewport(sf::FloatRect(viewportLeft, viewportTop, viewportWidth, viewportHeight));
     renderTexture->This.setView(view);
 }
-
 
 void sfRenderTexture_getView(const sfRenderTexture* renderTexture, float* centerX, float* centerY, float* sizeX,
 		float* sizeY, float* rotation, float* viewportLeft, float* viewportTop, float* viewportWidth,
@@ -108,7 +98,6 @@ void sfRenderTexture_getView(const sfRenderTexture* renderTexture, float* center
     *viewportWidth = view.getViewport().width;
     *viewportHeight = view.getViewport().height;
 }
-
 
 void sfRenderTexture_getDefaultView(const sfRenderTexture* renderTexture, float* centerX, float* centerY, float* sizeX,
 		float* sizeY, float* rotation, float* viewportLeft, float* viewportTop, float* viewportWidth,
@@ -137,38 +126,31 @@ void sfRenderTexture_drawPrimitives(sfRenderTexture* renderTexture,
     		colorDstFactor, colorEquation, alphaSrcFactor, alphaDstFactor, alphaEquation, transform, texture, shader));
 }
 
-
 void sfRenderTexture_pushGLStates(sfRenderTexture* renderTexture)
 {
     renderTexture->This.pushGLStates();
 }
-
 
 void sfRenderTexture_popGLStates(sfRenderTexture* renderTexture)
 {
     renderTexture->This.popGLStates();
 }
 
-
 void sfRenderTexture_resetGLStates(sfRenderTexture* renderTexture)
 {
     renderTexture->This.resetGLStates();
 }
 
-
 sfTexture* sfRenderTexture_getTexture(const sfRenderTexture* renderTexture)
 {
     //Safe because the pointer will only be used in a const instance
-    //return const_cast<sfTexture*>(renderTexture->Target);
     return new sfTexture(const_cast<sf::Texture*>(&renderTexture->This.getTexture()));
 }
-
 
 void sfRenderTexture_setSmooth(sfRenderTexture* renderTexture, DBool smooth)
 {
     renderTexture->This.setSmooth(smooth == DTrue);
 }
-
 
 DBool sfRenderTexture_isSmooth(const sfRenderTexture* renderTexture)
 {

--- a/src/DSFMLC/Graphics/RenderTextureStruct.h
+++ b/src/DSFMLC/Graphics/RenderTextureStruct.h
@@ -1,45 +1,41 @@
-////////////////////////////////////////////////////////////
-//
-// SFML - Simple and Fast Multimedia Library
-// Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-//
-// This software is provided 'as-is', without any express or implied warranty.
-// In no event will the authors be held liable for any damages arising from the use of this software.
-//
-// Permission is granted to anyone to use this software for any purpose,
-// including commercial applications, and to alter it and redistribute it freely,
-// subject to the following restrictions:
-//
-// 1. The origin of this software must not be misrepresented;
-//    you must not claim that you wrote the original software.
-//    If you use this software in a product, an acknowledgment
-//    in the product documentation would be appreciated but is not required.
-//
-// 2. Altered source versions must be plainly marked as such,
-//    and must not be misrepresented as being the original software.
-//
-// 3. This notice may not be removed or altered from any source distribution.
-//
-////////////////////////////////////////////////////////////
+/*
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef SFML_RENDERTEXTURESTRUCT_H
 #define SFML_RENDERTEXTURESTRUCT_H
 
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
 #include <SFML/Graphics/RenderTexture.hpp>
 #include <DSFMLC/Graphics/TextureStruct.h>
 
-
-////////////////////////////////////////////////////////////
-// Internal structure of sfRenderTexture
-////////////////////////////////////////////////////////////
+//Internal structure of sfRenderTexture
 struct sfRenderTexture
 {
     sf::RenderTexture This;
     const sfTexture*  Target;
 };
-
 
 #endif // SFML_RENDERTEXTURESTRUCT_H

--- a/src/DSFMLC/Graphics/RenderWindow.cpp
+++ b/src/DSFMLC/Graphics/RenderWindow.cpp
@@ -1,36 +1,30 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
-
-
-
-// Headers
 #include <DSFMLC/Graphics/RenderWindow.h>
 #include <DSFMLC/Graphics/RenderWindowStruct.h>
 #include <DSFMLC/Graphics/ImageStruct.h>
@@ -57,7 +51,6 @@ sfRenderWindow* sfRenderWindow_constructFromSettings(DUint width, DUint height, 
     params.majorVersion      = majorVersion;
     params.minorVersion      = minorVersion;
 
-
     // Create the window
     sfRenderWindow* renderWindow = new sfRenderWindow;
     renderWindow->This.create(videoMode, sf::String(std::basic_string<DUint>(title, titleLength)), style, params);
@@ -75,7 +68,6 @@ sfRenderWindow* sfRenderWindow_constructFromHandle(sfWindowHandle handle, DUint 
     params.antialiasingLevel = antialiasingLevel;
     params.majorVersion      = majorVersion;
     params.minorVersion      = minorVersion;
-
 
     // Create the window
     sfRenderWindow* renderWindow = new sfRenderWindow;
@@ -120,21 +112,15 @@ void sfRenderWindow_destroy(sfRenderWindow* renderWindow)
     delete renderWindow;
 }
 
-
-
 void sfRenderWindow_close(sfRenderWindow* renderWindow)
 {
     renderWindow->This.close();
 }
 
-
-
 DBool sfRenderWindow_isOpen(const sfRenderWindow* renderWindow)
 {
     return renderWindow->This.isOpen()?DTrue: DFalse;
 }
-
-
 
 void sfRenderWindow_getSettings(const sfRenderWindow* renderWindow, DUint* depthBits, DUint* stencilBits, DUint* antialiasingLevel, DUint* majorVersion, DUint* minorVersion)
 {
@@ -147,11 +133,8 @@ void sfRenderWindow_getSettings(const sfRenderWindow* renderWindow, DUint* depth
 
 }
 
-
-
 DBool sfRenderWindow_pollEvent(sfRenderWindow* renderWindow, DEvent* event)
 {
-
     // Get the event
     sf::Event SFMLEvent;
     DBool ret = renderWindow->This.pollEvent(SFMLEvent);
@@ -166,11 +149,8 @@ DBool sfRenderWindow_pollEvent(sfRenderWindow* renderWindow, DEvent* event)
     return DTrue;
 }
 
-
-
 DBool sfRenderWindow_waitEvent(sfRenderWindow* renderWindow, DEvent* event)
 {
-
     // Get the event
     sf::Event SFMLEvent;
     DBool ret = renderWindow->This.waitEvent(SFMLEvent);
@@ -185,126 +165,89 @@ DBool sfRenderWindow_waitEvent(sfRenderWindow* renderWindow, DEvent* event)
     return DTrue;
 }
 
-
-
 void sfRenderWindow_getPosition(const sfRenderWindow* renderWindow, DInt* x, DInt* y)
 {
-
     sf::Vector2i sfmlPos = renderWindow->This.getPosition();
     *x = sfmlPos.x;
     *y = sfmlPos.y;
-
 }
-
-
 
 void sfRenderWindow_setPosition(sfRenderWindow* renderWindow, DInt x, DInt y)
 {
     renderWindow->This.setPosition(sf::Vector2i(x, y));
 }
 
-
-
 void sfRenderWindow_getSize(const sfRenderWindow* renderWindow, DUint* width, DUint* height)
 {
     sf::Vector2u sfmlSize = renderWindow->This.getSize();
     *width = sfmlSize.x;
     *height = sfmlSize.y;
-
 }
-
-
 
 void sfRenderWindow_setSize(sfRenderWindow* renderWindow, DInt width, DInt height)
 {
     renderWindow->This.setSize(sf::Vector2u(width, height));
 }
 
-
-
 void sfRenderWindow_setTitle(sfRenderWindow* renderWindow, const char* title, size_t length)
 {
     renderWindow->This.setTitle(std::string(title, length));
 }
-
-
 
 void sfRenderWindow_setUnicodeTitle(sfRenderWindow* renderWindow, const DUint* title, size_t length)
 {
     renderWindow->This.setTitle(sf::String(std::basic_string<DUint>(title, length)));
 }
 
-
-
 void sfRenderWindow_setIcon(sfRenderWindow* renderWindow, DUint width, DUint height, const DUbyte* pixels)
 {
     renderWindow->This.setIcon(width, height, pixels);
 }
-
-
 
 void sfRenderWindow_setVisible(sfRenderWindow* renderWindow, DBool visible)
 {
     renderWindow->This.setVisible(visible == DTrue);
 }
 
-
-
 void sfRenderWindow_setMouseCursorVisible(sfRenderWindow* renderWindow, DBool visible)
 {
    renderWindow->This.setMouseCursorVisible(visible == DTrue);
 }
-
-
 
 void sfRenderWindow_setVerticalSyncEnabled(sfRenderWindow* renderWindow, DBool enabled)
 {
     renderWindow->This.setVerticalSyncEnabled(enabled == DTrue);
 }
 
-
-
 void sfRenderWindow_setKeyRepeatEnabled(sfRenderWindow* renderWindow, DBool enabled)
 {
     renderWindow->This.setKeyRepeatEnabled(enabled == DTrue);
 }
-
-
 
 DBool sfRenderWindow_setActive(sfRenderWindow* renderWindow, DBool active)
 {
     return renderWindow->This.setActive(active == DTrue)?DTrue: DFalse;
 }
 
-
-
 void sfRenderWindow_display(sfRenderWindow* renderWindow)
 {
     renderWindow->This.display();
 }
-
-
 
 void sfRenderWindow_setFramerateLimit(sfRenderWindow* renderWindow, DUint limit)
 {
     renderWindow->This.setFramerateLimit(limit);
 }
 
-
-
 void sfRenderWindow_setJoystickThreshold(sfRenderWindow* renderWindow, float threshold)
 {
     renderWindow->This.setJoystickThreshold(threshold);
 }
 
-
-
 sfWindowHandle sfRenderWindow_getSystemHandle(const sfRenderWindow* renderWindow)
 {
     return (sfWindowHandle)renderWindow->This.getSystemHandle();
 }
-
-
 
 void sfRenderWindow_clear(sfRenderWindow* renderWindow, DUbyte r, DUbyte g, DUbyte b, DUbyte a)
 {
@@ -312,8 +255,6 @@ void sfRenderWindow_clear(sfRenderWindow* renderWindow, DUbyte r, DUbyte g, DUby
 
     renderWindow->This.clear(SFMLColor);
 }
-
-
 
 void sfRenderWindow_setView(sfRenderWindow* renderWindow, float centerX, float centerY, float sizeX,
 		float sizeY, float rotation, float viewportLeft, float viewportTop, float viewportWidth,
@@ -344,7 +285,6 @@ void sfRenderWindow_getView(const sfRenderWindow* renderWindow, float* centerX, 
     *viewportHeight = view.getViewport().height;
 }
 
-
 void sfRenderWindow_getDefaultView(const sfRenderWindow* renderWindow, float* centerX, float* centerY, float* sizeX,
 		float* sizeY, float* rotation, float* viewportLeft, float* viewportTop, float* viewportWidth,
 		float* viewportHeight)
@@ -370,28 +310,20 @@ void sfRenderWindow_drawPrimitives(sfRenderWindow* renderWindow,
     		colorEquation, alphaSrcFactor, alphaDstFactor, alphaEquation, transform, texture, shader));
 }
 
-
-
 void sfRenderWindow_pushGLStates(sfRenderWindow* renderWindow)
 {
     renderWindow->This.pushGLStates();
 }
-
-
 
 void sfRenderWindow_popGLStates(sfRenderWindow* renderWindow)
 {
     renderWindow->This.popGLStates();
 }
 
-
-
 void sfRenderWindow_resetGLStates(sfRenderWindow* renderWindow)
 {
     renderWindow->This.resetGLStates();
 }
-
-
 
 sfImage* sfRenderWindow_capture(const sfRenderWindow* renderWindow)
 {
@@ -402,8 +334,6 @@ sfImage* sfRenderWindow_capture(const sfRenderWindow* renderWindow)
     return image;
 }
 
-
-
 void sfMouse_getPositionRenderWindow(const sfRenderWindow* relativeTo, DInt* x, DInt* y)
 {
     sf::Vector2i sfmlPos;
@@ -413,14 +343,10 @@ void sfMouse_getPositionRenderWindow(const sfRenderWindow* relativeTo, DInt* x, 
 
     *x = sfmlPos.x;
     *y = sfmlPos.y;
-
 }
-
-
 
 void sfMouse_setPositionRenderWindow(DInt x, DInt y, const sfRenderWindow* relativeTo)
 {
     //Will always be called with a Window
     sf::Mouse::setPosition(sf::Vector2i(x, y), relativeTo->This);
-
 }

--- a/src/DSFMLC/Graphics/RenderWindowStruct.h
+++ b/src/DSFMLC/Graphics/RenderWindowStruct.h
@@ -1,43 +1,39 @@
-////////////////////////////////////////////////////////////
-//
-// SFML - Simple and Fast Multimedia Library
-// Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-//
-// This software is provided 'as-is', without any express or implied warranty.
-// In no event will the authors be held liable for any damages arising from the use of this software.
-//
-// Permission is granted to anyone to use this software for any purpose,
-// including commercial applications, and to alter it and redistribute it freely,
-// subject to the following restrictions:
-//
-// 1. The origin of this software must not be misrepresented;
-//    you must not claim that you wrote the original software.
-//    If you use this software in a product, an acknowledgment
-//    in the product documentation would be appreciated but is not required.
-//
-// 2. Altered source versions must be plainly marked as such,
-//    and must not be misrepresented as being the original software.
-//
-// 3. This notice may not be removed or altered from any source distribution.
-//
-////////////////////////////////////////////////////////////
+/*
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef SFML_RENDERWINDOWSTRUCT_H
 #define SFML_RENDERWINDOWSTRUCT_H
 
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
 #include <SFML/Graphics/RenderWindow.hpp>
 
-
-////////////////////////////////////////////////////////////
-// Internal structure of sfRenderWindow
-////////////////////////////////////////////////////////////
+//Internal structure of sfRenderWindow
 struct sfRenderWindow
 {
     sf::RenderWindow This;
 };
-
 
 #endif // SFML_RENDERWINDOWSTRUCT_H

--- a/src/DSFMLC/Graphics/Shader.cpp
+++ b/src/DSFMLC/Graphics/Shader.cpp
@@ -1,34 +1,30 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
-
-// Headers
 #include <DSFMLC/Graphics/Shader.h>
 #include <DSFMLC/Graphics/ShaderStruct.h>
 #include <DSFMLC/Graphics/TextureStruct.h>
@@ -67,7 +63,6 @@ DBool sfShader_loadFromFile(sfShader* shader, const char* vertexShaderFilename, 
     return success?DTrue:DFalse;
 }
 
-
 DBool sfShader_loadFromMemory(sfShader* shader, const char* vertexShader, size_t vertexShaderLength,
 								const char* fragmentShader, size_t fragmentShaderLength)
 {
@@ -95,7 +90,6 @@ DBool sfShader_loadFromMemory(sfShader* shader, const char* vertexShader, size_t
 
     return success?DTrue:DFalse;
 }
-
 
 DBool sfShader_loadFromStream(sfShader* shader, DStream* vertexShaderStream, DStream* fragmentShaderStream)
 {
@@ -127,87 +121,71 @@ DBool sfShader_loadFromStream(sfShader* shader, DStream* vertexShaderStream, DSt
     return success?DTrue:DFalse;
 }
 
-
 void sfShader_destroy(sfShader* shader)
 {
     delete shader;
 }
-
-
-
 
 void sfShader_bind(const sfShader* shader)
 {
     sf::Shader::bind(shader ? &shader->This : 0);
 }
 
-
 DBool sfShader_isAvailable(void)
 {
     return sf::Shader::isAvailable() ? DTrue : DFalse;
 }
-
 
 void sfShader_setFloatUniform(sfShader* shader, const char* name, size_t length, float x)
 {
     shader->This.setUniform(std::string(name, length), x);
 }
 
-
 void sfShader_setVec2Uniform(sfShader* shader, const char* name, size_t length, const sf::Glsl::Vec2* vec2)
 {
     shader->This.setUniform(std::string(name, length), *vec2);
 }
-
 
 void sfShader_setVec3Uniform(sfShader* shader, const char* name, size_t length, const sf::Glsl::Vec3* vec3)
 {
     shader->This.setUniform(std::string(name, length), *vec3);
 }
 
-
 void sfShader_setVec4Uniform(sfShader* shader, const char* name, size_t length, const sf::Glsl::Vec4* vec4)
 {
     shader->This.setUniform(std::string(name, length), *vec4);
 }
-
 
 void sfShader_setIntUniform(sfShader* shader, const char* name, size_t length, int x)
 {
     shader->This.setUniform(std::string(name, length), x);
 }
 
-
 void sfShader_setIvec2Uniform(sfShader* shader, const char* name, size_t length, const sf::Glsl::Ivec2* ivec2)
 {
     shader->This.setUniform(std::string(name, length), *ivec2);
 }
-
 
 void sfShader_setIvec3Uniform(sfShader* shader, const char* name, size_t length, const sf::Glsl::Ivec3* ivec3)
 {
     shader->This.setUniform(std::string(name, length), *ivec3);
 }
 
-
 void sfShader_setIvec4Uniform(sfShader* shader, const char* name, size_t length, const sf::Glsl::Ivec4* ivec4)
 {
     shader->This.setUniform(std::string(name, length), *ivec4);
 }
-
 
 void sfShader_setBoolUniform(sfShader* shader, const char* name, size_t length, DBool x)
 {
     shader->This.setUniform(std::string(name, length), static_cast<bool>(x));
 }
 
-
 void sfShader_setBvec2Uniform(sfShader* shader, const char* name, size_t length, DBool x, DBool y)
 {
     shader->This.setUniform(std::string(name, length),
                    sf::Glsl::Bvec2(static_cast<bool>(x), static_cast<bool>(y)));
 }
-
 
 void sfShader_setBvec3Uniform(sfShader* shader, const char* name, size_t length, DBool x, DBool y, DBool z)
 {
@@ -216,7 +194,6 @@ void sfShader_setBvec3Uniform(sfShader* shader, const char* name, size_t length,
                                     static_cast<bool>(z)));
 }
 
-
 void sfShader_setBvec4Uniform(sfShader* shader, const char* name, size_t length, DBool x, DBool y, DBool z, DBool w)
 {
     shader->This.setUniform(std::string(name, length),
@@ -224,60 +201,50 @@ void sfShader_setBvec4Uniform(sfShader* shader, const char* name, size_t length,
                                    static_cast<bool>(z), static_cast<bool>(w)));
 }
 
-
 void sfShader_setMat3Uniform(sfShader* shader, const char* name, size_t length, const sf::Glsl::Mat3* mat3)
 {
     shader->This.setUniform(std::string(name, length),*mat3);
 }
-
 
 void sfShader_setMat4Uniform(sfShader* shader, const char* name, size_t length, const sf::Glsl::Mat4* mat4)
 {
     shader->This.setUniform(std::string(name, length),*mat4);
 }
 
-
 void sfShader_setTextureUniform(sfShader* shader, const char* name, size_t length, const sfTexture* texture)
 {
     shader->This.setUniform(std::string(name, length), *texture->This);
 }
-
 
 void sfShader_setCurrentTextureUniform(sfShader* shader, const char* name, size_t length)
 {
     shader->This.setUniform(std::string(name, length), sf::Shader::CurrentTextureType());
 }
 
-
 void sfShader_setFloatArrayUniform(sfShader* shader, const char* name, size_t nlength, const float* array, size_t alength)
 {
     shader->This.setUniformArray(std::string(name, nlength), array, alength);
 }
-
 
 void sfShader_setVec2ArrayUniform(sfShader* shader, const char* name, size_t nlength, const sf::Glsl::Vec2* array, size_t alength)
 {
     shader->This.setUniformArray(std::string(name, nlength), array, alength);
 }
 
-
 void sfShader_setVec3ArrayUniform(sfShader* shader, const char* name, size_t nlength, const sf::Glsl::Vec3* array, size_t alength)
 {
     shader->This.setUniformArray(std::string(name, nlength), array, alength);
 }
-
 
 void sfShader_setVec4ArrayUniform(sfShader* shader, const char* name, size_t nlength, const sf::Glsl::Vec4* array, size_t alength)
 {
     shader->This.setUniformArray(std::string(name, nlength), array, alength);
 }
 
-
 void sfShader_setMat3ArrayUniform(sfShader* shader, const char* name, size_t nlength, const sf::Glsl::Mat3* array, size_t alength)
 {
     shader->This.setUniformArray(std::string(name, nlength), array, alength);
 }
-
 
 void sfShader_setMat4ArrayUniform(sfShader* shader, const char* name, size_t nlength, const sf::Glsl::Mat4* array, size_t alength)
 {
@@ -291,42 +258,35 @@ void sfShader_setFloatParameter(sfShader* shader, const char* name, size_t lengt
     shader->This.setParameter(std::string(name, length), x);
 }
 
-
 void sfShader_setFloat2Parameter(sfShader* shader, const char* name, size_t length, float x, float y)
 {
     shader->This.setParameter(std::string(name, length), x, y);
 }
-
 
 void sfShader_setFloat3Parameter(sfShader* shader, const char* name, size_t length, float x, float y, float z)
 {
     shader->This.setParameter(std::string(name, length), x, y, z);
 }
 
-
 void sfShader_setFloat4Parameter(sfShader* shader, const char* name, size_t length, float x, float y, float z, float w)
 {
     shader->This.setParameter(std::string(name, length), x, y, z, w);
 }
-
 
 void sfShader_setColorParameter(sfShader* shader, const char* name, size_t length, DUbyte r, DUbyte g, DUbyte b, DUbyte a)
 {
     shader->This.setParameter(std::string(name, length), sf::Color(r, g, b, a));
 }
 
-
 void sfShader_setTransformParameter(sfShader* shader, const char* name, size_t length, float* transform)
 {
     shader->This.setParameter(std::string(name, length), createTransform(transform));
 }
 
-
 void sfShader_setTextureParameter(sfShader* shader, const char* name, size_t length, const sfTexture* texture)
 {
     shader->This.setParameter(std::string(name, length), *texture->This);
 }
-
 
 void sfShader_setCurrentTextureParameter(sfShader* shader, const char* name, size_t length)
 {

--- a/src/DSFMLC/Graphics/ShaderStruct.h
+++ b/src/DSFMLC/Graphics/ShaderStruct.h
@@ -1,43 +1,39 @@
-////////////////////////////////////////////////////////////
-//
-// SFML - Simple and Fast Multimedia Library
-// Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-//
-// This software is provided 'as-is', without any express or implied warranty.
-// In no event will the authors be held liable for any damages arising from the use of this software.
-//
-// Permission is granted to anyone to use this software for any purpose,
-// including commercial applications, and to alter it and redistribute it freely,
-// subject to the following restrictions:
-//
-// 1. The origin of this software must not be misrepresented;
-//    you must not claim that you wrote the original software.
-//    If you use this software in a product, an acknowledgment
-//    in the product documentation would be appreciated but is not required.
-//
-// 2. Altered source versions must be plainly marked as such,
-//    and must not be misrepresented as being the original software.
-//
-// 3. This notice may not be removed or altered from any source distribution.
-//
-////////////////////////////////////////////////////////////
+/*
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_SHADERSTRUCT_H
 #define DSFML_SHADERSTRUCT_H
 
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
 #include <SFML/Graphics/Shader.hpp>
 
-
-////////////////////////////////////////////////////////////
-// Internal structure of sfShader
-////////////////////////////////////////////////////////////
+//Internal structure of sfShader
 struct sfShader
 {
     sf::Shader This;
 };
-
 
 #endif // SFML_SHADERSTRUCT_H

--- a/src/DSFMLC/Graphics/Text.cpp
+++ b/src/DSFMLC/Graphics/Text.cpp
@@ -1,41 +1,35 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
-
-// Headers
 #include <DSFMLC/Graphics/Text.h>
 #include <DSFMLC/Graphics/TextStruct.h>
 #include <DSFMLC/Graphics/Font.h>
 #include <SFML/Graphics/Color.hpp>
 #include <DSFMLC/Graphics/CreateTransform.hpp>
-
-
 
 sfText* sfText_construct(void)
 {
@@ -45,42 +39,35 @@ sfText* sfText_construct(void)
     return text;
 }
 
-
 sfText* sfText_copy(const sfText* text)
 {
     return new sfText(*text);
 }
-
 
 void sfText_destroy(sfText* text)
 {
     delete text;
 }
 
-
 void sfText_setPosition(sfText* text, float positionX, float positionY)
 {
     text->This.setPosition(positionX, positionY);
 }
-
 
 void sfText_setRotation(sfText* text, float angle)
 {
     text->This.setRotation(angle);
 }
 
-
 void sfText_setScale(sfText* text, float scaleX, float scaleY)
 {
     text->This.setScale(scaleX, scaleY);
 }
 
-
 void sfText_setOrigin(sfText* text, float originX, float originY)
 {
     text->This.setOrigin(originX, originY);
 }
-
 
 void sfText_getPosition(const sfText* text, float* positionX, float* positionY)
 {
@@ -89,12 +76,10 @@ void sfText_getPosition(const sfText* text, float* positionX, float* positionY)
     *positionY = sfmlPos.y;
 }
 
-
 float sfText_getRotation(const sfText* text)
 {
     return text->This.getRotation();
 }
-
 
 void sfText_getScale(const sfText* text, float* scaleX, float* scaleY)
 {
@@ -103,7 +88,6 @@ void sfText_getScale(const sfText* text, float* scaleX, float* scaleY)
     *scaleY = sfmlScale.y;
 }
 
-
 void sfText_getOrigin(const sfText* text, float* originX, float* originY)
 {
     sf::Vector2f sfmlOrigin = text->This.getOrigin();
@@ -111,42 +95,35 @@ void sfText_getOrigin(const sfText* text, float* originX, float* originY)
     *originY = sfmlOrigin.y;
 }
 
-
 void sfText_move(sfText* text, float offsetX, float offsetY)
 {
     text->This.move(offsetX, offsetY);
 }
-
 
 void sfText_rotate(sfText* text, float angle)
 {
     text->This.rotate(angle);
 }
 
-
 void sfText_scale(sfText* text, float factorX, float factorY)
 {
     text->This.scale(factorX, factorY);
 }
-
 
 void sfText_getTransform(const sfText* text, float* transform)
 {
     createTransform(text->This.getTransform(), transform);
 }
 
-
 void sfText_getInverseTransform(const sfText* text, float* transform)
 {
     createTransform(text->This.getInverseTransform(), transform);
 }
 
-
 void sfText_setString(sfText* text, const char* string)
 {
     text->This.setString(string);
 }
-
 
 void sfText_setUnicodeString(sfText* text, const DUint* string)
 {
@@ -154,49 +131,41 @@ void sfText_setUnicodeString(sfText* text, const DUint* string)
     text->This.setString(UTF32Text);
 }
 
-
 void sfText_setFont(sfText* text, const sfFont* font)
 {
     text->This.setFont(font->This);
     text->Font = font;
 }
 
-
 void sfText_setCharacterSize(sfText* text, DUint size)
 {
     text->This.setCharacterSize(size);
 }
-
 
 void sfText_setStyle(sfText* text, DUint style)
 {
     text->This.setStyle(style);
 }
 
-
 void sfText_setColor(sfText* text, DUbyte r, DUbyte g, DUbyte b, DUbyte a)
 {
     text->This.setColor(sf::Color(r, g, b, a));
 }
-
 
 sfFont* sfText_getFont(const sfText* text)
 {
     return const_cast<sfFont*>(text->Font);
 }
 
-
 DUint sfText_getCharacterSize(const sfText* text)
 {
     return text->This.getCharacterSize();
 }
 
-
 DUint sfText_getStyle(const sfText* text)
 {
     return text->This.getStyle();
 }
-
 
 void sfText_getColor(const sfText* text, DUbyte* r, DUbyte* g, DUbyte* b, DUbyte* a)
 {
@@ -207,14 +176,12 @@ void sfText_getColor(const sfText* text, DUbyte* r, DUbyte* g, DUbyte* b, DUbyte
     *a = sfmlColor.a;
 }
 
-
 void sfText_findCharacterPos(const sfText* text, size_t index, float* posX, float* posY)
 {
     sf::Vector2f sfmlPos = text->This.findCharacterPos(index);
     *posX = sfmlPos.x;
     *posY = sfmlPos.y;
 }
-
 
 void sfText_getLocalBounds(const sfText* text, float* left, float* top, float* width, float* height)
 {
@@ -224,7 +191,6 @@ void sfText_getLocalBounds(const sfText* text, float* left, float* top, float* w
     *width = sfmlRect.width;
     *height = sfmlRect.height;
 }
-
 
 void sfText_getGlobalBounds(const sfText* text, float* left, float* top, float* width, float* height)
 {
@@ -244,7 +210,7 @@ DUint sfText_getVertexCount(const sfText* text)
 {
     return static_cast<DUint>(text->This.getVertexCount());
 }
-    
+
 DInt sfText_getPrimitiveType(const sfText* text)
 {
     return static_cast<DInt>(text->This.getPrimitiveType());

--- a/src/DSFMLC/Graphics/TextStruct.h
+++ b/src/DSFMLC/Graphics/TextStruct.h
@@ -1,41 +1,38 @@
-////////////////////////////////////////////////////////////
-//
-// SFML - Simple and Fast Multimedia Library
-// Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-//
-// This software is provided 'as-is', without any express or implied warranty.
-// In no event will the authors be held liable for any damages arising from the use of this software.
-//
-// Permission is granted to anyone to use this software for any purpose,
-// including commercial applications, and to alter it and redistribute it freely,
-// subject to the following restrictions:
-//
-// 1. The origin of this software must not be misrepresented;
-//    you must not claim that you wrote the original software.
-//    If you use this software in a product, an acknowledgment
-//    in the product documentation would be appreciated but is not required.
-//
-// 2. Altered source versions must be plainly marked as such,
-//    and must not be misrepresented as being the original software.
-//
-// 3. This notice may not be removed or altered from any source distribution.
-//
-////////////////////////////////////////////////////////////
+/*
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef SFML_TEXTSTRUCT_H
 #define SFML_TEXTSTRUCT_H
 
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
 #include <DSFMLC/Graphics/DText.hpp>
 #include <DSFMLC/Graphics/FontStruct.h>
 #include <DSFMLC/Config.h>
 
-
-////////////////////////////////////////////////////////////
-// Internal structure of sfText
-////////////////////////////////////////////////////////////
+//Internal structure of sfText
 struct sfText
 {
     sf::DText            This;
@@ -43,6 +40,5 @@ struct sfText
     mutable float Transform[9];
     mutable float InverseTransform[9];
 };
-
 
 #endif // SFML_TEXTSTRUCT_H

--- a/src/DSFMLC/Graphics/Texture.cpp
+++ b/src/DSFMLC/Graphics/Texture.cpp
@@ -1,32 +1,29 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #include <DSFMLC/Graphics/Texture.h>
 #include <DSFMLC/Graphics/TextureStruct.h>
@@ -34,20 +31,17 @@ All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license
 #include <DSFMLC/Graphics/RenderWindowStruct.h>
 #include <DSFMLC/Window/WindowStruct.h>
 
-
 //Construct a new texture
 sfTexture* sfTexture_construct(void)
 {
     return new sfTexture;
 }
 
-
 DBool sfTexture_create(sfTexture* texture, DUint width, DUint height)
 {
     return texture->This->create(width, height)?DTrue:DFalse;
 
 }
-
 
 DBool sfTexture_loadFromFile(sfTexture* texture, const char* filename, size_t filenameLength, DInt left, DInt top, DInt width, DInt height)
 {
@@ -56,14 +50,12 @@ DBool sfTexture_loadFromFile(sfTexture* texture, const char* filename, size_t fi
     return texture->This->loadFromFile(std::string(filename, filenameLength), rect)?DTrue:DFalse;
 }
 
-
 DBool sfTexture_loadFromMemory(sfTexture* texture, const void* data, size_t sizeInBytes, DInt left, DInt top, DInt width, DInt height)
 {
     sf::IntRect rect = sf::IntRect(left, top, width, height);
 
     return texture->This->loadFromMemory(data, sizeInBytes, rect)?DTrue:DFalse;
 }
-
 
 DBool sfTexture_loadFromStream(sfTexture* texture, DStream* stream, DInt left, DInt top, DInt width, DInt height)
 {
@@ -74,7 +66,6 @@ DBool sfTexture_loadFromStream(sfTexture* texture, DStream* stream, DInt left, D
     return texture->This->loadFromStream(Stream, rect)?DTrue:DFalse;
 }
 
-
 DBool sfTexture_loadFromImage(sfTexture* texture, const sfImage* image, DInt left, DInt top, DInt width, DInt height)
 {
     sf::IntRect rect = sf::IntRect(left, top, width, height);
@@ -82,18 +73,15 @@ DBool sfTexture_loadFromImage(sfTexture* texture, const sfImage* image, DInt lef
     return texture->This->loadFromImage(image->This, rect)?DTrue:DFalse;
 }
 
-
 sfTexture* sfTexture_copy(const sfTexture* texture)
 {
     return new sfTexture(*texture);
 }
 
-
 void sfTexture_destroy(sfTexture* texture)
 {
     delete texture;
 }
-
 
 void sfTexture_getSize(const sfTexture* texture, DUint* x, DUint* y)
 {
@@ -101,9 +89,7 @@ void sfTexture_getSize(const sfTexture* texture, DUint* x, DUint* y)
 
     *x = sfmlSize.x;
     *y = sfmlSize.y;
-
 }
-
 
 sfImage* sfTexture_copyToImage(const sfTexture* texture)
 {
@@ -113,60 +99,50 @@ sfImage* sfTexture_copyToImage(const sfTexture* texture)
     return image;
 }
 
-
 void sfTexture_updateFromPixels(sfTexture* texture, const DUbyte* pixels, DUint width, DUint height, DUint x, DUint y)
 {
    texture->This->update(pixels, width, height, x, y);
 }
-
 
 void sfTexture_updateFromImage(sfTexture* texture, const sfImage* image, DUint x, DUint y)
 {
     texture->This->update(image->This, x, y);
 }
 
-
 void sfTexture_updateFromWindow(sfTexture* texture, const void* window, DUint x, DUint y)
 {
     texture->This->update(static_cast<const sfWindow*>(window)->This, x, y);
 }
-
 
 void sfTexture_updateFromRenderWindow(sfTexture* texture, const sfRenderWindow* renderWindow, DUint x, DUint y)
 {
     texture->This->update(renderWindow->This, x, y);
 }
 
-
 void sfTexture_setSmooth(sfTexture* texture, DBool smooth)
 {
     texture->This->setSmooth(smooth == DTrue);
 }
-
 
 DBool sfTexture_isSmooth(const sfTexture* texture)
 {
     return texture->This->isSmooth();
 }
 
-
 void sfTexture_setRepeated(sfTexture* texture, DBool repeated)
 {
     texture->This->setRepeated(repeated == DTrue);
 }
-
 
 DBool sfTexture_isRepeated(const sfTexture* texture)
 {
     return texture->This->isRepeated();
 }
 
-
 void sfTexture_bind(const sfTexture* texture)
 {
     sf::Texture::bind(texture ? texture->This : NULL);
 }
-
 
 DUint sfTexture_getMaximumSize()
 {

--- a/src/DSFMLC/Graphics/TextureStruct.h
+++ b/src/DSFMLC/Graphics/TextureStruct.h
@@ -1,39 +1,36 @@
-////////////////////////////////////////////////////////////
-//
-// SFML - Simple and Fast Multimedia Library
-// Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-//
-// This software is provided 'as-is', without any express or implied warranty.
-// In no event will the authors be held liable for any damages arising from the use of this software.
-//
-// Permission is granted to anyone to use this software for any purpose,
-// including commercial applications, and to alter it and redistribute it freely,
-// subject to the following restrictions:
-//
-// 1. The origin of this software must not be misrepresented;
-//    you must not claim that you wrote the original software.
-//    If you use this software in a product, an acknowledgment
-//    in the product documentation would be appreciated but is not required.
-//
-// 2. Altered source versions must be plainly marked as such,
-//    and must not be misrepresented as being the original software.
-//
-// 3. This notice may not be removed or altered from any source distribution.
-//
-////////////////////////////////////////////////////////////
+/*
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef SFML_TEXTURESTRUCT_H
 #define SFML_TEXTURESTRUCT_H
 
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
 #include <SFML/Graphics/Texture.hpp>
 
-
-////////////////////////////////////////////////////////////
-// Internal structure of sfTexture
-////////////////////////////////////////////////////////////
+//Internal structure of sfTexture
 struct sfTexture
 {
     sfTexture()
@@ -63,6 +60,5 @@ struct sfTexture
     sf::Texture* This;
     bool OwnInstance;
 };
-
 
 #endif // SFML_TEXTURESTRUCT_H

--- a/src/DSFMLC/Graphics/Transform.cpp
+++ b/src/DSFMLC/Graphics/Transform.cpp
@@ -1,39 +1,34 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
-
-// Headers
 #include <DSFMLC/Graphics/Transform.h>
 #include <SFML/Graphics/Transform.hpp>
 #include <DSFMLC/Graphics/CreateTransform.hpp>
 #include <cstring>
-
 
 void sfTransform_getMatrix(const float* transform, float* matrix)
 {
@@ -42,14 +37,10 @@ void sfTransform_getMatrix(const float* transform, float* matrix)
         std::memcpy(matrix, createed.getMatrix(), 16 * sizeof(float));
 }
 
-
 void sfTransform_getInverse(const float* transform, float* inverse)
 {
     createTransform(createTransform(transform).getInverse(), inverse);
-
-
 }
-
 
 void sfTransform_transformPoint(const float* transform, float xIn, float yIn, float* xOut, float* yOut)
 {
@@ -57,9 +48,7 @@ void sfTransform_transformPoint(const float* transform, float xIn, float yIn, fl
 
     *xOut = sfmlPoint.x;
     *yOut = sfmlPoint.y;
-
 }
-
 
 void sfTransform_transformRect(const float* transform, float leftIn, float topIn, float widthIn, float heightIn, float* leftOut, float* topOut, float* widthOut, float* heightOut)
 {
@@ -69,39 +58,32 @@ void sfTransform_transformRect(const float* transform, float leftIn, float topIn
     *topOut = sfmlRect.top;
     *widthOut = sfmlRect.width;
     *heightOut = sfmlRect.height;
-
 }
-
 
 void sfTransform_combine(float* transform, const float* other)
 {
     createTransform(createTransform(transform).combine(createTransform(other)),transform);
 }
 
-
 void sfTransform_translate(float* transform, float x, float y)
 {
     createTransform(createTransform(transform).translate(x, y), transform);
 }
-
 
 void sfTransform_rotate(float* transform, float angle)
 {
     createTransform(createTransform(transform).rotate(angle),transform);
 }
 
-
 void sfTransform_rotateWithCenter(float* transform, float angle, float centerX, float centerY)
 {
     createTransform(createTransform(transform).rotate(angle, centerX, centerY),transform);
 }
 
-
 void sfTransform_scale(float* transform, float scaleX, float scaleY)
 {
     createTransform(createTransform(transform).scale(scaleX, scaleY),transform);
 }
-
 
 void sfTransform_scaleWithCenter(float* transform, float scaleX, float scaleY, float centerX, float centerY)
 {

--- a/src/DSFMLC/Network/Err.cpp
+++ b/src/DSFMLC/Network/Err.cpp
@@ -1,53 +1,49 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
-
-//Headers
 #include <DSFMLC/Network/Err.h>
 #include <SFML/System/Err.hpp>
 #include <sstream>
 #include <string>
 
-
 namespace
 {
-    std::ostringstream outputStream;//stream sf::err() get's redirected to
-    std::string outputString;//string for storing output
-}
+    //stream sf::err() get's redirected to
+    std::ostringstream outputStream;
 
+    //string for storing output
+    std::string outputString;
+}
 
 void sfErrNetwork_redirect(void)
 {
     //redirect sf::err() to write to outputStream
     sf::err().rdbuf(outputStream.rdbuf());
 }
-
 
 const char* sfErrNetwork_getOutput(void)
 {
@@ -59,4 +55,3 @@ const char* sfErrNetwork_getOutput(void)
 
     return outputString.c_str();
 }
-

--- a/src/DSFMLC/Network/Ftp.cpp
+++ b/src/DSFMLC/Network/Ftp.cpp
@@ -1,35 +1,30 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on Laurent Gomila's SFML library.***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML
-*/
-
-
-// Headers
 #include <DSFMLC/Network/Ftp.h>
 #include <DSFMLC/Network/FtpStruct.h>
 #include <SFML/Network/IpAddress.hpp>
@@ -41,30 +36,25 @@ void sfFtpListingResponse_destroy(sfFtpListingResponse* ftpListingResponse)
     delete ftpListingResponse;
 }
 
-
 DInt sfFtpListingResponse_getStatus(const sfFtpListingResponse* ftpListingResponse)
 {
     return ftpListingResponse->This.getStatus();
 }
-
 
 const char* sfFtpListingResponse_getMessage(const sfFtpListingResponse* ftpListingResponse)
 {
     return ftpListingResponse->This.getMessage().c_str();
 }
 
-
 size_t sfFtpListingResponse_getCount(const sfFtpListingResponse* ftpListingResponse)
 {
     return ftpListingResponse->This.getListing().size();
 }
 
-
 const char* sfFtpListingResponse_getName(const sfFtpListingResponse* ftpListingResponse, size_t index)
 {
     return ftpListingResponse->This.getListing()[index].c_str();
 }
-
 
 ///FTP Directory Responce Functions
 
@@ -73,24 +63,20 @@ void sfFtpDirectoryResponse_destroy(sfFtpDirectoryResponse* ftpDirectoryResponse
     delete ftpDirectoryResponse;
 }
 
-
 DInt sfFtpDirectoryResponse_getStatus(const sfFtpDirectoryResponse* ftpDirectoryResponse)
 {
     return ftpDirectoryResponse->This.getStatus();
 }
-
 
 const char* sfFtpDirectoryResponse_getMessage(const sfFtpDirectoryResponse* ftpDirectoryResponse)
 {
     return ftpDirectoryResponse->This.getMessage().c_str();
 }
 
-
 const char* sfFtpDirectoryResponse_getDirectory(const sfFtpDirectoryResponse* ftpDirectoryResponse)
 {
     return ftpDirectoryResponse->This.getDirectory().c_str();
 }
-
 
 ///FTP Responce Functions
 
@@ -99,20 +85,15 @@ void sfFtpResponse_destroy(sfFtpResponse* ftpResponse)
     delete ftpResponse;
 }
 
-
-
-
 DInt sfFtpResponse_getStatus(const sfFtpResponse* ftpResponse)
 {
     return ftpResponse->This.getStatus();
 }
 
-
 const char* sfFtpResponse_getMessage(const sfFtpResponse* ftpResponse)
 {
     return ftpResponse->This.getMessage().c_str();
 }
-
 
 ///FTP Functions
 
@@ -121,90 +102,75 @@ sfFtp* sfFtp_create(void)
     return new sfFtp;
 }
 
-
 void sfFtp_destroy(sfFtp* ftp)
 {
     delete ftp;
 }
-
 
 sfFtpResponse* sfFtp_connect(sfFtp* ftp, sf::IpAddress* serverIP, DUshort port, DLong timeout)
 {
     return new sfFtpResponse(ftp->This.connect(*serverIP, port, sf::microseconds(timeout)));
 }
 
-
 sfFtpResponse* sfFtp_loginAnonymous(sfFtp* ftp)
 {
     return new sfFtpResponse(ftp->This.login());
 }
-
 
 sfFtpResponse* sfFtp_login(sfFtp* ftp, const char* userName, size_t userNameLength, const char* password, size_t passwordLength)
 {
     return new sfFtpResponse(ftp->This.login(userName ? std::string(userName, userNameLength) : "", password ? std::string(password, passwordLength) : ""));
 }
 
-
 sfFtpResponse* sfFtp_disconnect(sfFtp* ftp)
 {
     return new sfFtpResponse(ftp->This.disconnect());
 }
-
 
 sfFtpResponse* sfFtp_keepAlive(sfFtp* ftp)
 {
     return new sfFtpResponse(ftp->This.keepAlive());
 }
 
-
 sfFtpDirectoryResponse* sfFtp_getWorkingDirectory(sfFtp* ftp)
 {
     return new sfFtpDirectoryResponse(ftp->This.getWorkingDirectory());
 }
-
 
 sfFtpListingResponse* sfFtp_getDirectoryListing(sfFtp* ftp, const char* directory, size_t length)
 {
     return new sfFtpListingResponse(ftp->This.getDirectoryListing(directory ? std::string(directory, length) : ""));
 }
 
-
 sfFtpResponse* sfFtp_changeDirectory(sfFtp* ftp, const char* directory, size_t length)
 {
     return new sfFtpResponse(ftp->This.changeDirectory(directory ? std::string(directory, length) : ""));
 }
-
 
 sfFtpResponse* sfFtp_parentDirectory(sfFtp* ftp)
 {
     return new sfFtpResponse(ftp->This.parentDirectory());
 }
 
-
 sfFtpResponse* sfFtp_createDirectory(sfFtp* ftp, const char* name, size_t length)
 {
     return new sfFtpResponse(ftp->This.createDirectory(name ? std::string(name, length) : ""));
 }
-
 
 sfFtpResponse* sfFtp_deleteDirectory(sfFtp* ftp, const char* name, size_t length)
 {
     return new sfFtpResponse(ftp->This.deleteDirectory(name ? std::string(name, length) : ""));
 }
 
-
 sfFtpResponse* sfFtp_renameFile(sfFtp* ftp, const char* file, size_t fileLength, const char* newName, size_t newNameLength)
 {
     return new sfFtpResponse(ftp->This.renameFile(file ? std::string(file, fileLength) : "", newName ? std::string(newName, newNameLength) : ""));
 }
 
-
 sfFtpResponse* sfFtp_deleteFile(sfFtp* ftp, const char* name, size_t length)
 {
     return new sfFtpResponse(ftp->This.deleteFile(name ? std::string(name, length) : ""));
 }
-
 
 sfFtpResponse* sfFtp_download(sfFtp* ftp, const char* distantFile, size_t distantFileLength, const char* destPath, size_t destPathLength, DInt mode)
 {
@@ -212,7 +178,6 @@ sfFtpResponse* sfFtp_download(sfFtp* ftp, const char* distantFile, size_t distan
                                                 destPath ? std::string(destPath, destPathLength) : "",
                                                 static_cast<sf::Ftp::TransferMode>(mode)));
 }
-
 
 sfFtpResponse* sfFtp_upload(sfFtp* ftp, const char* localFile, size_t localFileLength, const char* destPath, size_t destPathLength, DInt mode)
 {

--- a/src/DSFMLC/Network/FtpStruct.h
+++ b/src/DSFMLC/Network/FtpStruct.h
@@ -1,49 +1,43 @@
-////////////////////////////////////////////////////////////
-//
-// SFML - Simple and Fast Multimedia Library
-// Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-//
-// This software is provided 'as-is', without any express or implied warranty.
-// In no event will the authors be held liable for any damages arising from the use of this software.
-//
-// Permission is granted to anyone to use this software for any purpose,
-// including commercial applications, and to alter it and redistribute it freely,
-// subject to the following restrictions:
-//
-// 1. The origin of this software must not be misrepresented;
-//    you must not claim that you wrote the original software.
-//    If you use this software in a product, an acknowledgment
-//    in the product documentation would be appreciated but is not required.
-//
-// 2. Altered source versions must be plainly marked as such,
-//    and must not be misrepresented as being the original software.
-//
-// 3. This notice may not be removed or altered from any source distribution.
-//
-////////////////////////////////////////////////////////////
+/*
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_FTPSTRUCT_H
 #define DSFML_FTPSTRUCT_H
 
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
 #include <SFML/Network/Ftp.hpp>
 #include <vector>
 
-
-////////////////////////////////////////////////////////////
-// Internal structure of sfFtp
-////////////////////////////////////////////////////////////
+//Internal structure of sfFtp
 struct sfFtp
 {
     sf::Ftp This;
 };
 
-
-////////////////////////////////////////////////////////////
-// Internal structure of sfFtpResponse
-////////////////////////////////////////////////////////////
+//Internal structure of sfFtpResponse
 struct sfFtpResponse
 {
     sfFtpResponse(const sf::Ftp::Response& Response)
@@ -54,10 +48,7 @@ struct sfFtpResponse
     sf::Ftp::Response This;
 };
 
-
-////////////////////////////////////////////////////////////
-// Internal structure of sfFtpDirectoryResponse
-////////////////////////////////////////////////////////////
+//Internal structure of sfFtpDirectoryResponse
 struct sfFtpDirectoryResponse
 {
     sfFtpDirectoryResponse(const sf::Ftp::DirectoryResponse& Response)
@@ -68,10 +59,7 @@ struct sfFtpDirectoryResponse
     sf::Ftp::DirectoryResponse This;
 };
 
-
-////////////////////////////////////////////////////////////
-// Internal structure of sfFtpListingResponse
-////////////////////////////////////////////////////////////
+//Internal structure of sfFtpListingResponse
 struct sfFtpListingResponse
 {
     sfFtpListingResponse(const sf::Ftp::ListingResponse& Response)
@@ -88,6 +76,5 @@ struct sfFtpListingResponse
     sf::Ftp::ListingResponse This;
     std::vector<const char*> Filenames;
 };
-
 
 #endif // DSFML_FTPSTRUCT_H

--- a/src/DSFMLC/Network/Http.cpp
+++ b/src/DSFMLC/Network/Http.cpp
@@ -1,37 +1,32 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on Laurent Gomila's SFML library.***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML
-*/
-
-// Headers
 #include <DSFMLC/Network/Http.h>
 #include <DSFMLC/Network/HttpStruct.h>
-
 
 ///HTTP Request Functions
 
@@ -40,14 +35,10 @@ sfHttpRequest* sfHttpRequest_create(void)
     return new sfHttpRequest;
 }
 
-
-
 void sfHttpRequest_destroy(sfHttpRequest* httpRequest)
 {
     delete httpRequest;
 }
-
-
 
 void sfHttpRequest_setField(sfHttpRequest* httpRequest, const char* field, size_t fieldLength, const char* value, size_t valueLength)
 {
@@ -55,34 +46,25 @@ void sfHttpRequest_setField(sfHttpRequest* httpRequest, const char* field, size_
         httpRequest->This.setField(std::string(field, fieldLength), std::string(value, valueLength));
 }
 
-
-
 void sfHttpRequest_setMethod(sfHttpRequest* httpRequest, DInt method)
 {
     httpRequest->This.setMethod(static_cast<sf::Http::Request::Method>(method));
 }
-
-
 
 void sfHttpRequest_setUri(sfHttpRequest* httpRequest, const char* uri, size_t length)
 {
     httpRequest->This.setUri(uri ? std::string(uri, length) : "");
 }
 
-
-
 void sfHttpRequest_setHttpVersion(sfHttpRequest* httpRequest, DUint major, DUint minor)
 {
     httpRequest->This.setHttpVersion(major, minor);
 }
 
-
-
 void sfHttpRequest_setBody(sfHttpRequest* httpRequest, const char* body, size_t length)
 {
     httpRequest->This.setBody(body ? std::string(body, length) : "");
 }
-
 
 ///HTTP Response Functions
 
@@ -90,7 +72,6 @@ void sfHttpResponse_destroy(sfHttpResponse* httpResponse)
 {
     delete httpResponse;
 }
-
 
 const char* sfHttpResponse_getField(const sfHttpResponse* httpResponse, const char* field, size_t length)
 {
@@ -100,34 +81,26 @@ const char* sfHttpResponse_getField(const sfHttpResponse* httpResponse, const ch
     return httpResponse->This.getField(std::string(field, length)).c_str();
 }
 
-
 DInt sfHttpResponse_getStatus(const sfHttpResponse* httpResponse)
 {
     return httpResponse->This.getStatus();
 }
-
-
 
 DUint sfHttpResponse_getMajorVersion(const sfHttpResponse* httpResponse)
 {
    return httpResponse->This.getMajorHttpVersion();
 }
 
-
-
 DUint sfHttpResponse_getMinorVersion(const sfHttpResponse* httpResponse)
 {
     return httpResponse->This.getMinorHttpVersion();
 }
-
-
 
 const char* sfHttpResponse_getBody(const sfHttpResponse* httpResponse)
 {
 
     return httpResponse->This.getBody().c_str();
 }
-
 
 ///HTTP Functions
 
@@ -136,21 +109,15 @@ sfHttp* sfHttp_create(void)
     return new sfHttp;
 }
 
-
-
 void sfHttp_destroy(sfHttp* http)
 {
     delete http;
 }
 
-
-
 void sfHttp_setHost(sfHttp* http, const char* host, size_t length, DUshort port)
 {
     http->This.setHost(host ? std::string(host, length) : "", port);
 }
-
-
 
 sfHttpResponse* sfHttp_sendRequest(sfHttp* http, const sfHttpRequest* request, DLong timeout)
 {

--- a/src/DSFMLC/Network/HttpStruct.h
+++ b/src/DSFMLC/Network/HttpStruct.h
@@ -1,61 +1,51 @@
-////////////////////////////////////////////////////////////
-//
-// SFML - Simple and Fast Multimedia Library
-// Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-//
-// This software is provided 'as-is', without any express or implied warranty.
-// In no event will the authors be held liable for any damages arising from the use of this software.
-//
-// Permission is granted to anyone to use this software for any purpose,
-// including commercial applications, and to alter it and redistribute it freely,
-// subject to the following restrictions:
-//
-// 1. The origin of this software must not be misrepresented;
-//    you must not claim that you wrote the original software.
-//    If you use this software in a product, an acknowledgment
-//    in the product documentation would be appreciated but is not required.
-//
-// 2. Altered source versions must be plainly marked as such,
-//    and must not be misrepresented as being the original software.
-//
-// 3. This notice may not be removed or altered from any source distribution.
-//
-////////////////////////////////////////////////////////////
+/*
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef SFML_HTTPSTRUCT_H
 #define SFML_HTTPSTRUCT_H
 
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
 #include <SFML/Network/Http.hpp>
 
-
-////////////////////////////////////////////////////////////
-// Internal structure of sfHttp
-////////////////////////////////////////////////////////////
+//Internal structure of sfHttp
 struct sfHttp
 {
     sf::Http This;
 };
 
-
-////////////////////////////////////////////////////////////
-// Internal structure of sfHttpRequest
-////////////////////////////////////////////////////////////
+//Internal structure of sfHttpRequest
 struct sfHttpRequest
 {
     sf::Http::Request This;
 };
 
-
-////////////////////////////////////////////////////////////
-// Internal structure of sfHttpResponse
-////////////////////////////////////////////////////////////
+//Internal structure of sfHttpResponse
 struct sfHttpResponse
 {
     sf::Http::Response This;
 };
-
 
 #endif // SFML_HTTPSTRUCT_H

--- a/src/DSFMLC/Network/IpAddress.cpp
+++ b/src/DSFMLC/Network/IpAddress.cpp
@@ -1,50 +1,43 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on Laurent Gomila's SFML library.***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 // Headers
 #include <DSFMLC/Network/IpAddress.h>
 #include <string.h>
-
-
 
 DUint sfIpAddress_integerFromString(const char* address, size_t addressLength)
 {
     return sf::IpAddress(std::string(address, addressLength)).toInteger();
 }
 
-
 void sfIpAddress_getLocalAddress(sf::IpAddress* ipAddress)
 {
      *ipAddress = sf::IpAddress::getLocalAddress();
 }
-
 
 void sfIpAddress_getPublicAddress(sf::IpAddress* ipAddress, DLong timeout)
 {

--- a/src/DSFMLC/Network/Packet.cpp
+++ b/src/DSFMLC/Network/Packet.cpp
@@ -1,135 +1,118 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on Laurent Gomila's SFML library.***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML
-*/
-
-
-// Headers
 #include <DSFMLC/Network/Packet.h>
 #include <DSFMLC/Network/PacketStruct.h>
 
-
-////////////////////////////////////////////////////////////
 sfPacket* sfPacket_create(void)
 {
     return new sfPacket;
 }
-
 
 sfPacket* sfPacket_copy(const sfPacket* packet)
 {
     return new sfPacket(*packet);
 }
 
-
 void sfPacket_destroy(sfPacket* packet)
 {
     delete packet;
 }
-
-
 
 void sfPacket_append(sfPacket* packet, const void* data, size_t sizeInBytes)
 {
     packet->This.append(data, sizeInBytes);
 }
 
-
-////////////////////////////////////////////////////////////
 void sfPacket_clear(sfPacket* packet)
 {
     packet->This.clear();
 }
 
-
-////////////////////////////////////////////////////////////
 const void* sfPacket_getData(const sfPacket* packet)
 {
    return packet->This.getData();
 }
 
-
-////////////////////////////////////////////////////////////
 size_t sfPacket_getDataSize(const sfPacket* packet)
 {
     return packet->This.getDataSize();
 }
 
-
-////////////////////////////////////////////////////////////
 DBool sfPacket_endOfPacket(const sfPacket* packet)
 {
     return packet->This.endOfPacket()?DTrue:DFalse;
 }
 
-
-////////////////////////////////////////////////////////////
 DBool sfPacket_canRead(const sfPacket* packet)
 {
     return packet->This ? DTrue : DFalse;
 }
 
-
-////////////////////////////////////////////////////////////
 DBool sfPacket_readBool(sfPacket* packet)
 {
     return sfPacket_readUint8(packet);
 }
+
 DByte sfPacket_readInt8(sfPacket* packet)
 {
     DByte value;
     packet->This >> value;
     return value;
 }
+
 DUbyte sfPacket_readUint8(sfPacket* packet)
 {
     DUbyte value;
     packet->This >> value;
     return value;
 }
+
 DShort sfPacket_readInt16(sfPacket* packet)
 {
     DShort value;
     packet->This >> value;
     return value;
 }
+
 DUshort sfPacket_readUint16(sfPacket* packet)
 {
     DUshort value;
     packet->This >> value;
     return value;
 }
+
 DInt sfPacket_readInt32(sfPacket* packet)
 {
     DInt value;
     packet->This >> value;
     return value;
 }
+
 DUint sfPacket_readUint32(sfPacket* packet)
 {
     DInt value;
@@ -157,6 +140,7 @@ float sfPacket_readFloat(sfPacket* packet)
     packet->This >> value;
     return value;
 }
+
 double sfPacket_readDouble(sfPacket* packet)
 {
     double value;
@@ -165,51 +149,57 @@ double sfPacket_readDouble(sfPacket* packet)
 }
 
 
-
-
-////////////////////////////////////////////////////////////
 void sfPacket_writeBool(sfPacket* packet, DBool value)
 {
     sfPacket_writeUint8(packet, value ? 1 : 0);
 }
+
 void sfPacket_writeInt8(sfPacket* packet, DByte value)
 {
     packet->This << value;
 }
+
 void sfPacket_writeUint8(sfPacket* packet, DUbyte value)
 {
     packet->This << value;
 }
+
 void sfPacket_writeInt16(sfPacket* packet, DShort value)
 {
     packet->This << value;
 }
+
 void sfPacket_writeUint16(sfPacket* packet, DUshort value)
 {
     packet->This << value;
 }
+
 void sfPacket_writeInt32(sfPacket* packet, DInt value)
 {
     packet->This << value;
 }
+
 void sfPacket_writeUint64(sfPacket* packet, DUint value)
 {
     packet->This << value;
 }
+
 void sfPacket_writeInt64(sfPacket* packet, DLong value)
 {
     packet->This << value;
 }
+
 void sfPacket_writeUint32(sfPacket* packet, DUlong value)
 {
     packet->This << value;
 }
+
 void sfPacket_writeFloat(sfPacket* packet, float value)
 {
     packet->This << value;
 }
+
 void sfPacket_writeDouble(sfPacket* packet, double value)
 {
     packet->This << value;
 }
-

--- a/src/DSFMLC/Network/PacketStruct.h
+++ b/src/DSFMLC/Network/PacketStruct.h
@@ -1,43 +1,39 @@
-////////////////////////////////////////////////////////////
-//
-// SFML - Simple and Fast Multimedia Library
-// Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-//
-// This software is provided 'as-is', without any express or implied warranty.
-// In no event will the authors be held liable for any damages arising from the use of this software.
-//
-// Permission is granted to anyone to use this software for any purpose,
-// including commercial applications, and to alter it and redistribute it freely,
-// subject to the following restrictions:
-//
-// 1. The origin of this software must not be misrepresented;
-//    you must not claim that you wrote the original software.
-//    If you use this software in a product, an acknowledgment
-//    in the product documentation would be appreciated but is not required.
-//
-// 2. Altered source versions must be plainly marked as such,
-//    and must not be misrepresented as being the original software.
-//
-// 3. This notice may not be removed or altered from any source distribution.
-//
-////////////////////////////////////////////////////////////
+/*
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_PACKETSTRUCT_H
 #define DSFML_PACKETSTRUCT_H
 
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
 #include <SFML/Network/Packet.hpp>
 
-
-////////////////////////////////////////////////////////////
-// Internal structure of sfPacket
-////////////////////////////////////////////////////////////
+//Internal structure of sfPacket
 struct sfPacket
 {
     sf::Packet This;
 };
-
 
 #endif // DSFML_PACKETSTRUCT_H

--- a/src/DSFMLC/Network/SocketSelector.cpp
+++ b/src/DSFMLC/Network/SocketSelector.cpp
@@ -1,110 +1,101 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on Laurent Gomila's SFML library.***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML
-*/
-
-
-// Headers
 #include <DSFMLC/Network/SocketSelector.h>
 #include <DSFMLC/Network/SocketSelectorStruct.h>
 #include <DSFMLC/Network/TcpListenerStruct.h>
 #include <DSFMLC/Network/TcpSocketStruct.h>
 #include <DSFMLC/Network/UdpSocketStruct.h>
 
-
 sfSocketSelector* sfSocketSelector_create(void)
 {
     return new sfSocketSelector;
 }
 
-
 sfSocketSelector* sfSocketSelector_copy(const sfSocketSelector* selector)
 {
-
     return new sfSocketSelector(*selector);
 }
-
 
 void sfSocketSelector_destroy(sfSocketSelector* selector)
 {
     delete selector;
 }
 
-
 void sfSocketSelector_addTcpListener(sfSocketSelector* selector, sfTcpListener* socket)
 {
     selector->This.add(socket->This);
 }
+
 void sfSocketSelector_addTcpSocket(sfSocketSelector* selector, sfTcpSocket* socket)
 {
     selector->This.add(socket->This);
 }
+
 void sfSocketSelector_addUdpSocket(sfSocketSelector* selector, sfUdpSocket* socket)
 {
     selector->This.add(socket->This);
 }
 
-
-
 void sfSocketSelector_removeTcpListener(sfSocketSelector* selector, sfTcpListener* socket)
 {
     selector->This.remove(socket->This);
 }
+
 void sfSocketSelector_removeTcpSocket(sfSocketSelector* selector, sfTcpSocket* socket)
 {
     selector->This.remove(socket->This);
 }
+
 void sfSocketSelector_removeUdpSocket(sfSocketSelector* selector, sfUdpSocket* socket)
 {
     selector->This.remove(socket->This);
 }
-
 
 void sfSocketSelector_clear(sfSocketSelector* selector)
 {
     selector->This.clear();
 }
 
-
 DBool sfSocketSelector_wait(sfSocketSelector* selector, DLong timeout)
 {
     return selector->This.wait(sf::microseconds(timeout))?DTrue: DFalse;
 }
 
-
 DBool sfSocketSelector_isTcpListenerReady(const sfSocketSelector* selector, sfTcpListener* socket)
 {
     return selector->This.isReady(socket->This)?DTrue: DFalse;
 }
+
 DBool sfSocketSelector_isTcpSocketReady(const sfSocketSelector* selector, sfTcpSocket* socket)
 {
     return selector->This.isReady(socket->This)?DTrue: DFalse;
 }
+
 DBool sfSocketSelector_isUdpSocketReady(const sfSocketSelector* selector, sfUdpSocket* socket)
 {
     return selector->This.isReady(socket->This)?DTrue: DFalse;

--- a/src/DSFMLC/Network/SocketSelectorStruct.h
+++ b/src/DSFMLC/Network/SocketSelectorStruct.h
@@ -1,43 +1,39 @@
-////////////////////////////////////////////////////////////
-//
-// SFML - Simple and Fast Multimedia Library
-// Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-//
-// This software is provided 'as-is', without any express or implied warranty.
-// In no event will the authors be held liable for any damages arising from the use of this software.
-//
-// Permission is granted to anyone to use this software for any purpose,
-// including commercial applications, and to alter it and redistribute it freely,
-// subject to the following restrictions:
-//
-// 1. The origin of this software must not be misrepresented;
-//    you must not claim that you wrote the original software.
-//    If you use this software in a product, an acknowledgment
-//    in the product documentation would be appreciated but is not required.
-//
-// 2. Altered source versions must be plainly marked as such,
-//    and must not be misrepresented as being the original software.
-//
-// 3. This notice may not be removed or altered from any source distribution.
-//
-////////////////////////////////////////////////////////////
+/*
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef SFML_SOCKETSELECTORSTRUCT_H
 #define SFML_SOCKETSELECTORSTRUCT_H
 
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
 #include <SFML/Network/SocketSelector.hpp>
 
-
-////////////////////////////////////////////////////////////
-// Internal structure of sfSocketSelector
-////////////////////////////////////////////////////////////
+//Internal structure of sfSocketSelector
 struct sfSocketSelector
 {
     sf::SocketSelector This;
 };
-
 
 #endif // SFML_SOCKETSELECTORSTRUCT_H

--- a/src/DSFMLC/Network/TcpListener.cpp
+++ b/src/DSFMLC/Network/TcpListener.cpp
@@ -1,76 +1,63 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on Laurent Gomila's SFML library.***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML
-*/
-
-
-// Headers
 #include <DSFMLC/Network/TcpListener.h>
 #include <DSFMLC/Network/TcpListenerStruct.h>
 #include <DSFMLC/Network/TcpSocketStruct.h>
-
 
 sfTcpListener* sfTcpListener_create(void)
 {
     return new sfTcpListener;
 }
 
-
 void sfTcpListener_destroy(sfTcpListener* listener)
 {
     delete listener;
 }
-
 
 void sfTcpListener_setBlocking(sfTcpListener* listener, DBool blocking)
 {
     listener->This.setBlocking(blocking == DTrue);
 }
 
-
 DBool sfTcpListener_isBlocking(const sfTcpListener* listener)
 {
     return listener->This.isBlocking()?DTrue: DFalse;
 }
-
-
 
 DUshort sfTcpListener_getLocalPort(const sfTcpListener* listener)
 {
     return listener->This.getLocalPort();
 }
 
-
 DInt sfTcpListener_listen(sfTcpListener* listener,DUshort port, const sf::IpAddress* address)
 {
     return listener->This.listen(port, *address);
 }
-
 
 DInt sfTcpListener_accept(sfTcpListener* listener, sfTcpSocket* connected)
 {

--- a/src/DSFMLC/Network/TcpListenerStruct.h
+++ b/src/DSFMLC/Network/TcpListenerStruct.h
@@ -1,43 +1,39 @@
-////////////////////////////////////////////////////////////
-//
-// SFML - Simple and Fast Multimedia Library
-// Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-//
-// This software is provided 'as-is', without any express or implied warranty.
-// In no event will the authors be held liable for any damages arising from the use of this software.
-//
-// Permission is granted to anyone to use this software for any purpose,
-// including commercial applications, and to alter it and redistribute it freely,
-// subject to the following restrictions:
-//
-// 1. The origin of this software must not be misrepresented;
-//    you must not claim that you wrote the original software.
-//    If you use this software in a product, an acknowledgment
-//    in the product documentation would be appreciated but is not required.
-//
-// 2. Altered source versions must be plainly marked as such,
-//    and must not be misrepresented as being the original software.
-//
-// 3. This notice may not be removed or altered from any source distribution.
-//
-////////////////////////////////////////////////////////////
+/*
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef SFML_TCPLISTENERSTRUCT_H
 #define SFML_TCPLISTENERSTRUCT_H
 
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
 #include <SFML/Network/TcpListener.hpp>
 
-
-////////////////////////////////////////////////////////////
-// Internal structure of sfTcpListener
-////////////////////////////////////////////////////////////
+//Internal structure of sfTcpListener
 struct sfTcpListener
 {
     sf::TcpListener This;
 };
-
 
 #endif // SFML_TCPLISTENERSTRUCT_H

--- a/src/DSFMLC/Network/TcpSocket.cpp
+++ b/src/DSFMLC/Network/TcpSocket.cpp
@@ -1,35 +1,30 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on Laurent Gomila's SFML library.***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML
-*/
-
-
-// Headers
 #include <DSFMLC/Network/TcpSocket.h>
 #include <DSFMLC/Network/TcpSocketStruct.h>
 #include <DSFMLC/Network/PacketStruct.h>
@@ -41,55 +36,45 @@ sfTcpSocket* sfTcpSocket_create(void)
     return new sfTcpSocket;
 }
 
-
 void sfTcpSocket_destroy(sfTcpSocket* socket)
 {
     delete socket;
 }
-
 
 void sfTcpSocket_setBlocking(sfTcpSocket* socket, DBool blocking)
 {
     socket->This.setBlocking(blocking == DTrue);
 }
 
-
 DBool sfTcpSocket_isBlocking(const sfTcpSocket* socket)
 {
     return socket->This.isBlocking()?DTrue: DFalse;
 }
-
 
 DUshort sfTcpSocket_getLocalPort(const sfTcpSocket* socket)
 {
     return socket->This.getLocalPort();
 }
 
-
 void sfTcpSocket_getRemoteAddress(const sfTcpSocket* socket, sf::IpAddress* ipAddress)
 {
-
     *ipAddress = socket->This.getRemoteAddress();
 }
-
 
 DUshort sfTcpSocket_getRemotePort(const sfTcpSocket* socket)
 {
     return socket->This.getRemotePort();
 }
 
-
 DInt sfTcpSocket_connect(sfTcpSocket* socket, const sf::IpAddress* ipAddress, DUshort port, DLong timeout)
 {
     return socket->This.connect(*ipAddress, port, sf::microseconds(timeout));
 }
 
-
 void sfTcpSocket_disconnect(sfTcpSocket* socket)
 {
     socket->This.disconnect();
 }
-
 
 DInt sfTcpSocket_send(sfTcpSocket* socket, const void* data, size_t size)
 {
@@ -97,18 +82,15 @@ DInt sfTcpSocket_send(sfTcpSocket* socket, const void* data, size_t size)
     return socket->This.send(data, size);
 }
 
-
 DInt sfTcpSocket_receive(sfTcpSocket* socket, void* data, size_t maxSize, size_t* sizeReceived)
 {
     return socket->This.receive(data, maxSize, *sizeReceived);
 }
 
-
 DInt sfTcpSocket_sendPacket(sfTcpSocket* socket, sfPacket* packet)
 {
     return socket->This.send(packet->This);
 }
-
 
 DInt sfTcpSocket_receivePacket(sfTcpSocket* socket, sfPacket* packet)
 {

--- a/src/DSFMLC/Network/TcpSocketStruct.h
+++ b/src/DSFMLC/Network/TcpSocketStruct.h
@@ -1,43 +1,39 @@
-////////////////////////////////////////////////////////////
-//
-// SFML - Simple and Fast Multimedia Library
-// Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-//
-// This software is provided 'as-is', without any express or implied warranty.
-// In no event will the authors be held liable for any damages arising from the use of this software.
-//
-// Permission is granted to anyone to use this software for any purpose,
-// including commercial applications, and to alter it and redistribute it freely,
-// subject to the following restrictions:
-//
-// 1. The origin of this software must not be misrepresented;
-//    you must not claim that you wrote the original software.
-//    If you use this software in a product, an acknowledgment
-//    in the product documentation would be appreciated but is not required.
-//
-// 2. Altered source versions must be plainly marked as such,
-//    and must not be misrepresented as being the original software.
-//
-// 3. This notice may not be removed or altered from any source distribution.
-//
-////////////////////////////////////////////////////////////
+/*
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef SFML_TCPSOCKETSTRUCT_H
 #define SFML_TCPSOCKETSTRUCT_H
 
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
 #include <SFML/Network/TcpSocket.hpp>
 
-
-////////////////////////////////////////////////////////////
-// Internal structure of sfTcpSocket
-////////////////////////////////////////////////////////////
+//Internal structure of sfTcpSocket
 struct sfTcpSocket
 {
     sf::TcpSocket This;
 };
-
 
 #endif // SFML_TCPSOCKETSTRUCT_H

--- a/src/DSFMLC/Network/UdpSocket.cpp
+++ b/src/DSFMLC/Network/UdpSocket.cpp
@@ -1,89 +1,75 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on Laurent Gomila's SFML library.***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML
-*/
-
-
-// Headers
 #include <DSFMLC/Network/UdpSocket.h>
 #include <DSFMLC/Network/UdpSocketStruct.h>
 #include <DSFMLC/Network/PacketStruct.h>
 #include <SFML/Network/IpAddress.hpp>
 #include <string.h>
 
-
 sfUdpSocket* sfUdpSocket_create(void)
 {
     return new sfUdpSocket;
 }
-
 
 void sfUdpSocket_destroy(sfUdpSocket* socket)
 {
     delete socket;
 }
 
-
 void sfUdpSocket_setBlocking(sfUdpSocket* socket, DBool blocking)
 {
     socket->This.setBlocking(blocking == DTrue);
 }
-
 
 DBool sfUdpSocket_isBlocking(const sfUdpSocket* socket)
 {
     return socket->This.isBlocking()?DTrue: DFalse;
 }
 
-
 DUshort sfUdpSocket_getLocalPort(const sfUdpSocket* socket)
 {
     return socket->This.getLocalPort();
 }
-
 
 DInt sfUdpSocket_bind(sfUdpSocket* socket, DUshort port, sf::IpAddress* ipAddress)
 {
     return static_cast<DInt>(socket->This.bind(port, *ipAddress));
 }
 
-
 void sfUdpSocket_unbind(sfUdpSocket* socket)
 {
     socket->This.unbind();
 }
 
-
 DInt sfUdpSocket_send(sfUdpSocket* socket, const void* data, size_t size, sf::IpAddress* receiver, DUshort port)
 {
     return static_cast<DInt>(socket->This.send(data, size, *receiver, port));
 }
-
 
 DInt sfUdpSocket_receive(sfUdpSocket* socket, void* data, size_t maxSize, size_t* sizeReceived, sf::IpAddress* sender, DUshort* port)
 {
@@ -91,12 +77,10 @@ DInt sfUdpSocket_receive(sfUdpSocket* socket, void* data, size_t maxSize, size_t
                                                   *sender, *port));
 }
 
-
 DInt sfUdpSocket_sendPacket(sfUdpSocket* socket, sfPacket* packet, sf::IpAddress* receiver, DUshort port)
 {
     return static_cast<DInt>(socket->This.send(packet->This, *receiver, port));
 }
-
 
 DInt sfUdpSocket_receivePacket(sfUdpSocket* socket, sfPacket* packet, sf::IpAddress* sender, DUshort* port)
 {

--- a/src/DSFMLC/Network/UdpSocketStruct.h
+++ b/src/DSFMLC/Network/UdpSocketStruct.h
@@ -1,43 +1,39 @@
-////////////////////////////////////////////////////////////
-//
-// SFML - Simple and Fast Multimedia Library
-// Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-//
-// This software is provided 'as-is', without any express or implied warranty.
-// In no event will the authors be held liable for any damages arising from the use of this software.
-//
-// Permission is granted to anyone to use this software for any purpose,
-// including commercial applications, and to alter it and redistribute it freely,
-// subject to the following restrictions:
-//
-// 1. The origin of this software must not be misrepresented;
-//    you must not claim that you wrote the original software.
-//    If you use this software in a product, an acknowledgment
-//    in the product documentation would be appreciated but is not required.
-//
-// 2. Altered source versions must be plainly marked as such,
-//    and must not be misrepresented as being the original software.
-//
-// 3. This notice may not be removed or altered from any source distribution.
-//
-////////////////////////////////////////////////////////////
+/*
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef SFML_UDPSOCKETSTRUCT_H
 #define SFML_UDPSOCKETSTRUCT_H
 
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
 #include <SFML/Network/UdpSocket.hpp>
 
-
-////////////////////////////////////////////////////////////
-// Internal structure of sfUdpSocket
-////////////////////////////////////////////////////////////
+//Internal structure of sfUdpSocket
 struct sfUdpSocket
 {
     sf::UdpSocket This;
 };
-
 
 #endif // SFML_UDPSOCKETSTRUCT_H

--- a/src/DSFMLC/System/Err.cpp
+++ b/src/DSFMLC/System/Err.cpp
@@ -1,53 +1,49 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
-
-//Headers
 #include <DSFMLC/System/Err.h>
 #include <SFML/System/Err.hpp>
 #include <sstream>
 #include <string>
 
-
 namespace
 {
-    std::ostringstream outputStream;//stream sf::err() get's redirected to
-    std::string outputString;//string for storing output
-}
+    //stream sf::err() get's redirected to
+    std::ostringstream outputStream;
 
+    //string for storing output
+    std::string outputString;
+}
 
 void sfErr_redirect(void)
 {
     //redirect sf::err() to write to outputStream
     sf::err().rdbuf(outputStream.rdbuf());
 }
-
 
 const char* sfErr_getOutput(void)
 {
@@ -59,4 +55,3 @@ const char* sfErr_getOutput(void)
 
     return outputString.c_str();
 }
-

--- a/src/DSFMLC/System/String.cpp
+++ b/src/DSFMLC/System/String.cpp
@@ -1,3 +1,30 @@
+/*
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
+
 #include <DSFMLC/System/String.h>
 #include <SFML/System/Utf.hpp>
 
@@ -13,23 +40,22 @@ void utf16to8(const DUshort* inStr, size_t inLen, const DUbyte* outStr, size_t* 
 {
 	std::basic_string<DUshort> in;
 	in.insert(0,inStr, inLen);
-   
+
     utf8Out.clear();
-   
+
    sf::Utf16::toUtf8(in.begin(), in.end(), utf8Out.begin());
 
 	outStr = utf8Out.data();
 	*outLen = utf8Out.length();
-	
-
 }
+
 void utf32to8(const DUint* inStr, size_t inLen, const DUbyte* outStr, size_t* outLen)
 {
     std::basic_string<DUint> in;
 	in.insert(0,inStr, inLen);
-   
+
     utf8Out.clear();
-   
+
    sf::Utf32::toUtf8(in.begin(), in.end(), utf8Out.begin());
 
 	outStr = utf8Out.data();
@@ -41,21 +67,22 @@ void utf8to16(const DUbyte* inStr, size_t inLen, const DUshort* outStr, size_t* 
 {
     std::basic_string<DUbyte> in;
 	in.insert(0,inStr, inLen);
-   
+
     utf16Out.clear();
-   
+
    sf::Utf8::toUtf16(in.begin(), in.end(), utf16Out.begin());
 
 	outStr = utf16Out.data();
 	*outLen = utf16Out.length();
 }
+
 void utf32to16(const DUint* inStr, size_t inLen, const DUshort* outStr, size_t* outLen)
 {
     std::basic_string<DUint> in;
 	in.insert(0,inStr, inLen);
-   
+
     utf8Out.clear();
-   
+
    sf::Utf32::toUtf16(in.begin(), in.end(), utf16Out.begin());
 
 	outStr = utf16Out.data();
@@ -67,21 +94,22 @@ void utf8to32(const DUbyte* inStr, size_t inLen, const DUint* outStr, size_t* ou
 {
     std::basic_string<DUbyte> in;
 	in.insert(0,inStr, inLen);
-   
+
     utf32Out.clear();
-   
+
    sf::Utf8::toUtf32(in.begin(), in.end(), utf32Out.begin());
 
 	outStr = utf32Out.data();
 	*outLen = utf32Out.length();
 }
+
 void utf16to32(const DUshort* inStr, size_t inLen, const DUint* outStr, size_t* outLen)
 {
     std::basic_string<DUshort> in;
 	in.insert(0,inStr, inLen);
-   
+
     utf32Out.clear();
-   
+
    sf::Utf16::toUtf32(in.begin(), in.end(), utf32Out.begin());
 
 	outStr = utf32Out.data();

--- a/src/DSFMLC/System/Threads.cpp
+++ b/src/DSFMLC/System/Threads.cpp
@@ -1,34 +1,30 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
-
-//Headers
 #include <X11/Xlib.h>
 #include <DSFMLC/System/Threads.h>
 

--- a/src/DSFMLC/Window/Context.cpp
+++ b/src/DSFMLC/Window/Context.cpp
@@ -1,53 +1,42 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
-
-
-// Headers
 #include <DSFMLC/Window/Context.h>
 #include <DSFMLC/Window/ContextStruct.h>
-
-
 
 sfContext* sfContext_create(void)
 {
     return new sfContext;
 }
 
-
-
 void sfContext_destroy(sfContext* context)
 {
     delete context;
 }
-
-
 
 void sfContext_setActive(sfContext* context, DBool active)
 {

--- a/src/DSFMLC/Window/ContextStruct.h
+++ b/src/DSFMLC/Window/ContextStruct.h
@@ -1,45 +1,39 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_CONTEXTSTRUCT_H
 #define DSFML_CONTEXTSTRUCT_H
 
-// Headers
 #include <SFML/Window/Context.hpp>
-
 
 // Internal structure of sfContext
 struct sfContext
 {
     sf::Context This;
 };
-
 
 #endif // DSFML_CONTEXTSTRUCT_H

--- a/src/DSFMLC/Window/ConvertEvent.h
+++ b/src/DSFMLC/Window/ConvertEvent.h
@@ -1,46 +1,41 @@
-////////////////////////////////////////////////////////////
-//
-// SFML - Simple and Fast Multimedia Library
-// Copyright (C) 2007-2009 Laurent Gomila (laurent.gom@gmail.com)
-//
-// This software is provided 'as-is', without any express or implied warranty.
-// In no event will the authors be held liable for any damages arising from the use of this software.
-//
-// Permission is granted to anyone to use this software for any purpose,
-// including commercial applications, and to alter it and redistribute it freely,
-// subject to the following restrictions:
-//
-// 1. The origin of this software must not be misrepresented;
-//    you must not claim that you wrote the original software.
-//    If you use this software in a product, an acknowledgment
-//    in the product documentation would be appreciated but is not required.
-//
-// 2. Altered source versions must be plainly marked as such,
-//    and must not be misrepresented as being the original software.
-//
-// 3. This notice may not be removed or altered from any source distribution.
-//
-////////////////////////////////////////////////////////////
+/*
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_CONVERTEVENT_H
 #define DSFML_CONVERTEVENT_H
 
-////////////////////////////////////////////////////////////
-// Headers
-////////////////////////////////////////////////////////////
 #include <SFML/Window/Event.hpp>
 #include <DSFMLC/Window/Event.h>
 
-
-
-////////////////////////////////////////////////////////////
-// Define a function to convert a sf::Event ot a sfEvent
-////////////////////////////////////////////////////////////
+//Define a function to convert a sf::Event ot a sfEvent
 inline void convertEvent(const sf::Event& SFMLEvent, DEvent* event)
 {
     // Convert its type
     event->type = static_cast<DEvent::EventType>(SFMLEvent.type);
-
 
     // Fill its fields
     switch (event->type)
@@ -104,4 +99,3 @@ inline void convertEvent(const sf::Event& SFMLEvent, DEvent* event)
 }
 
 #endif // DSFML_CONVERTEVENT_H
-

--- a/src/DSFMLC/Window/Err.cpp
+++ b/src/DSFMLC/Window/Err.cpp
@@ -1,53 +1,49 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
-
-//Headers
 #include <DSFMLC/Window/Err.h>
 #include <SFML/System/Err.hpp>
 #include <sstream>
 #include <string>
 
-
 namespace
 {
-    std::ostringstream outputStream;//stream sf::err() get's redirected to
-    std::string outputString;//string for storing output
-}
+    //stream sf::err() get's redirected to
+    std::ostringstream outputStream;
 
+    //string for storing output
+    std::string outputString;
+}
 
 void sfErrWindow_redirect(void)
 {
     //redirect sf::err() to write to outputStream
     sf::err().rdbuf(outputStream.rdbuf());
 }
-
 
 const char* sfErrWindow_getOutput(void)
 {
@@ -59,4 +55,3 @@ const char* sfErrWindow_getOutput(void)
 
     return outputString.c_str();
 }
-

--- a/src/DSFMLC/Window/Joystick.cpp
+++ b/src/DSFMLC/Window/Joystick.cpp
@@ -1,67 +1,52 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
-
-
-// Headers
 #include <DSFMLC/Window/Joystick.h>
 #include <SFML/Window/Joystick.hpp>
-
-
 
 DBool sfJoystick_isConnected(DUint joystick)
 {
     return sf::Joystick::isConnected(joystick) ? DTrue : DFalse;
 }
 
-
-
 DUint sfJoystick_getButtonCount(DUint joystick)
 {
     return sf::Joystick::getButtonCount(joystick);
 }
-
-
 
 DBool sfJoystick_hasAxis(DUint joystick, DInt axis)
 {
     return sf::Joystick::hasAxis(joystick, static_cast<sf::Joystick::Axis>(axis)) ? DTrue : DFalse;
 }
 
-
-
 DBool sfJoystick_isButtonPressed(DUint joystick, DUint button)
 {
     return sf::Joystick::isButtonPressed(joystick, button) ? DTrue : DFalse;
 }
-
-
 
 float sfJoystick_getAxisPosition(DUint joystick, DInt axis)
 {
@@ -92,7 +77,6 @@ void sfJoystick_getIdentification(DUint joystick, DUint * vendorId, DUint* produ
 	*vendorId = sfmlIdentification.vendorId;
 	*productId = sfmlIdentification.productId;
 }
-
 
 void sfJoystick_update(void)
 {

--- a/src/DSFMLC/Window/Keyboard.cpp
+++ b/src/DSFMLC/Window/Keyboard.cpp
@@ -1,39 +1,32 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
-
-
-// Headers
 #include <DSFMLC/Window/Keyboard.h>
 #include <SFML/Window/Keyboard.hpp>
-
-
 
 DBool sfKeyboard_isKeyPressed(DInt key)
 {

--- a/src/DSFMLC/Window/Mouse.cpp
+++ b/src/DSFMLC/Window/Mouse.cpp
@@ -1,46 +1,39 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 // Headers
 #include <DSFMLC/Window/Mouse.h>
 #include <DSFMLC/Window/WindowStruct.h>
 #include <SFML/Window/Mouse.hpp>
 
-
-
 DBool sfMouse_isButtonPressed(DInt button)
 {
     return sf::Mouse::isButtonPressed(static_cast<sf::Mouse::Button>(button)) ? DTrue : DFalse;
 }
-
-
 
 void sfMouse_getPosition(const sfWindow* relativeTo, DInt* x, DInt* y)
 {
@@ -53,8 +46,6 @@ void sfMouse_getPosition(const sfWindow* relativeTo, DInt* x, DInt* y)
     *x = sfmlPos.x;
     *y = sfmlPos.y;
 }
-
-
 
 void sfMouse_setPosition(DInt x, DInt y, const sfWindow* relativeTo)
 {

--- a/src/DSFMLC/Window/Sensor.cpp
+++ b/src/DSFMLC/Window/Sensor.cpp
@@ -1,34 +1,30 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
-
-// Headers
 #include <DSFMLC/Window/Sensor.h>
 #include <SFML/Window/Sensor.hpp>
 #include <SFML/System/Vector3.hpp>

--- a/src/DSFMLC/Window/Touch.cpp
+++ b/src/DSFMLC/Window/Touch.cpp
@@ -1,34 +1,30 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
-
-// Headers
 #include <DSFMLC/Window/Touch.h>
 #include <DSFMLC/Window/WindowStruct.h>
 #include <SFML/Window/Touch.hpp>

--- a/src/DSFMLC/Window/VideoMode.cpp
+++ b/src/DSFMLC/Window/VideoMode.cpp
@@ -1,40 +1,33 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
-
-
-// Headers
 #include <DSFMLC/Window/VideoMode.h>
 #include <SFML/Window/VideoMode.hpp>
 
-
-////////////////////////////////////////////////////////////
 void sfVideoMode_getDesktopMode(DUint* width, DUint* height, DUint* bitsPerPixel)
 {
     sf::VideoMode desktop = sf::VideoMode::getDesktopMode();
@@ -46,11 +39,8 @@ void sfVideoMode_getDesktopMode(DUint* width, DUint* height, DUint* bitsPerPixel
 
 }
 
-
-////////////////////////////////////////////////////////////
 const DUint* sfVideoMode_getFullscreenModes(size_t* count)
 {
-
     static std::vector<DUint> modes;
 
     // Populate the array on first call
@@ -72,8 +62,6 @@ const DUint* sfVideoMode_getFullscreenModes(size_t* count)
     return !modes.empty() ? &modes[0] : NULL;
 }
 
-
-////////////////////////////////////////////////////////////
 DBool sfVideoMode_isValid(DUint width, DUint height, DUint bitsPerPixel)
 {
     sf::VideoMode videoMode(width, height, bitsPerPixel);

--- a/src/DSFMLC/Window/Window.cpp
+++ b/src/DSFMLC/Window/Window.cpp
@@ -1,39 +1,34 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
-
-// Headers
 #include <DSFMLC/Window/Window.h>
 #include <DSFMLC/Window/WindowStruct.h>
 #include <DSFMLC/ConvertEvent.h>
 #include <SFML/System/String.hpp>
-
 
 sfWindow* sfWindow_construct(void)
 {
@@ -54,7 +49,6 @@ void sfWindow_createFromSettings(sfWindow* window, DUint width, DUint height, DU
         params.majorVersion      = majorVersion;
         params.minorVersion      = minorVersion;
 
-
     window->This.create(videoMode, sf::String(std::basic_string<DUint>(title, titleLength)), style, params);
 }
 
@@ -71,25 +65,20 @@ void sfWindow_createFromHandle(sfWindow* window, sfWindowHandle handle, DUint de
     window->This.create(handle, params);
 }
 
-
-
 void sfWindow_destroy(sfWindow* window)
 {
     delete window;
 }
-
 
 void sfWindow_close(sfWindow* window)
 {
     window->This.close();
 }
 
-
 DBool sfWindow_isOpen(const sfWindow* window)
 {
     return window->This.isOpen()?DTrue:DFalse;
 }
-
 
 void sfWindow_getSettings(const sfWindow* window, DUint* depthBits, DUint* stencilBits, DUint* antialiasingLevel, DUint* majorVersion, DUint* minorVersion)
 {
@@ -100,14 +89,10 @@ void sfWindow_getSettings(const sfWindow* window, DUint* depthBits, DUint* stenc
     *antialiasingLevel = params.antialiasingLevel;
     *majorVersion      = params.majorVersion;
     *minorVersion      = params.minorVersion;
-
 }
-
-
 
 DBool sfWindow_pollEvent(sfWindow* window, DEvent* event)
 {
-
     // Get the event
     sf::Event SFMLEvent;
     bool ret = window->This.pollEvent(SFMLEvent);
@@ -121,7 +106,6 @@ DBool sfWindow_pollEvent(sfWindow* window, DEvent* event)
 
     return DTrue;
 }
-
 
 DBool sfWindow_waitEvent(sfWindow* window, DEvent* event)
 {
@@ -140,7 +124,6 @@ DBool sfWindow_waitEvent(sfWindow* window, DEvent* event)
     return DTrue;
 }
 
-
 void sfWindow_getPosition(const sfWindow* window, DInt* x, DInt* y)
 {
     sf::Vector2i sfmlPos = window->This.getPosition();
@@ -148,76 +131,62 @@ void sfWindow_getPosition(const sfWindow* window, DInt* x, DInt* y)
     *y = sfmlPos.y;
 }
 
-
 void sfWindow_setPosition(sfWindow* window, DInt x, DInt y)
 {
    window->This.setPosition(sf::Vector2i(x, y));
 }
-
 
 void sfWindow_getSize(const sfWindow* window, DUint* width, DUint* height)
 {
     sf::Vector2u sfmlSize = window->This.getSize();
     *width = sfmlSize.x;
     *height = sfmlSize.y;
-
-
 }
-
 
 void sfWindow_setSize(sfWindow* window, DUint width, DUint height)
 {
     window->This.setSize(sf::Vector2u(width, height));
 }
 
-
 void sfWindow_setTitle(sfWindow* window, const char* title)
 {
     window->This.setTitle(title);
 }
-
 
 void sfWindow_setUnicodeTitle(sfWindow* window, const DUint* title, size_t length)
 {
     window->This.setTitle(std::basic_string<DUint>(title, length));
 }
 
-
 void sfWindow_setIcon(sfWindow* window, DUint width, DUint height, const DUbyte* pixels)
 {
     window->This.setIcon(width, height, pixels);
 }
-
 
 void sfWindow_setVisible(sfWindow* window, DBool visible)
 {
     window->This.setVisible(visible == DTrue);
 }
 
-
 void sfWindow_setMouseCursorVisible(sfWindow* window, DBool visible)
 {
     window->This.setMouseCursorVisible(visible == DTrue);
 }
-
 
 void sfWindow_setVerticalSyncEnabled(sfWindow* window, DBool enabled)
 {
     window->This.setVerticalSyncEnabled(enabled == DTrue);
 }
 
-
 void sfWindow_setKeyRepeatEnabled(sfWindow* window, DBool enabled)
 {
     window->This.setKeyRepeatEnabled(enabled == DTrue);
 }
 
-
 DBool sfWindow_setActive(sfWindow* window, DBool active)
 {
     return window->This.setActive(active == DTrue)?DTrue: DFalse;
 }
-
 
 void sfWindow_display(sfWindow* window)
 {
@@ -233,18 +202,15 @@ DBool sfWindow_hasFocus(const sfWindow * window) {
 	return (window->This.hasFocus())?DTrue: DFalse;
 }
 
-
 void sfWindow_setFramerateLimit(sfWindow* window, DUint limit)
 {
     window->This.setFramerateLimit(limit);
 }
 
-
 void sfWindow_setJoystickThreshold(sfWindow* window, float threshold)
 {
     window->This.setJoystickThreshold(threshold);
 }
-
 
 sfWindowHandle sfWindow_getSystemHandle(const sfWindow* window)
 {

--- a/src/DSFMLC/Window/WindowStruct.h
+++ b/src/DSFMLC/Window/WindowStruct.h
@@ -1,45 +1,39 @@
 /*
-DSFML - The Simple and Fast Multimedia Library for D
-
-Copyright (c) <2013> <Jeremy DeHaan>
-
-This software is provided 'as-is', without any express or implied warranty.
-In no event will the authors be held liable for any damages arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose, including commercial applications,
-and to alter it and redistribute it freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not claim that you wrote the original software.
-If you use this software in a product, an acknowledgment in the product documentation would be appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution
-
-
-***All code is based on code written by Laurent Gomila***
-
-
-External Libraries Used:
-
-SFML - The Simple and Fast Multimedia Library
-Copyright (C) 2007-2013 Laurent Gomila (laurent.gom@gmail.com)
-
-All Libraries used by SFML - For a full list see http://www.sfml-dev.org/license.php
-*/
+ * DSFML - The Simple and Fast Multimedia Library for D
+ *
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ *
+ * This software is provided 'as-is', without any express or implied warranty.
+ * In no event will the authors be held liable for any damages arising from the
+ * use of this software.
+ *
+ * Permission is granted to anyone to use this software for any purpose,
+ * including commercial applications, and to alter it and redistribute it
+ * freely, subject to the following restrictions:
+ *
+ * 1. The origin of this software must not be misrepresented; you must not claim
+ * that you wrote the original software. If you use this software in a product,
+ * an acknowledgment in the product documentation would be appreciated but is
+ * not required.
+ *
+ * 2. Altered source versions must be plainly marked as such, and must not be
+ * misrepresented as being the original software.
+ *
+ * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
+ */
 
 #ifndef DSFML_WINDOWSTRUCT_H
 #define DSFML_WINDOWSTRUCT_H
 
-// Headers
 #include <SFML/Window/Window.hpp>
-
 
 // Internal structure of sfWindow
 struct sfWindow
 {
     sf::Window This;
 };
-
 
 #endif // DSFML_WINDOWSTRUCT_H

--- a/src/dsfml/audio/inputsoundfile.d
+++ b/src/dsfml/audio/inputsoundfile.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**

--- a/src/dsfml/audio/listener.d
+++ b/src/dsfml/audio/listener.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -74,6 +77,7 @@ final abstract class Listener
             sfListener_setDirection(orientation.x, orientation.y,
                                     orientation.z);
         }
+
         /// ditto
         static Vector3f direction()
         {
@@ -99,6 +103,7 @@ final abstract class Listener
         {
             sfListener_setUpVector(orientation.x, orientation.y, orientation.z);
         }
+
         /// ditto
         static Vector3f upVector()
         {
@@ -124,12 +129,12 @@ final abstract class Listener
         {
             sfListener_setGlobalVolume(volume);
         }
+
         /// ditto
         static float globalVolume()
         {
             return sfListener_getGlobalVolume();
         }
-
     }
 
     @property
@@ -143,6 +148,7 @@ final abstract class Listener
         {
             sfListener_setPosition(pos.x, pos.y, pos.z);
         }
+
         /// ditto
         static Vector3f position()
         {
@@ -172,6 +178,7 @@ final abstract class Listener
             sfListener_setDirection(orientation.x, orientation.y,
                                     orientation.z);
         }
+
         /// ditto
         static Vector3f Direction()
         {
@@ -200,6 +207,7 @@ final abstract class Listener
         {
             sfListener_setUpVector(orientation.x, orientation.y, orientation.z);
         }
+
         /// ditto
         static Vector3f UpVector()
         {
@@ -227,12 +235,12 @@ final abstract class Listener
         {
             sfListener_setGlobalVolume(volume);
         }
+
         /// ditto
         static float GlobalVolume()
         {
             return sfListener_getGlobalVolume();
         }
-
     }
 
     deprecated("Use the 'position' property instead.")
@@ -249,6 +257,7 @@ final abstract class Listener
         {
             sfListener_setPosition(position.x, position.y, position.z);
         }
+
         /// ditto
         static Vector3f Position()
         {

--- a/src/dsfml/audio/music.d
+++ b/src/dsfml/audio/music.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -284,9 +287,7 @@ class Music : SoundStream
 
             // Initialize the stream
             super.initialize(channelCount, sampleRate);
-
         }
-
     }
 }
 
@@ -318,9 +319,6 @@ unittest
         }
 
         music.stop();
-
-
-
 
         writeln();
     }

--- a/src/dsfml/audio/outputsoundfile.d
+++ b/src/dsfml/audio/outputsoundfile.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -111,7 +114,6 @@ class OutputSoundFile
 }
 
 extern(C) const(char)* sfErr_getOutput();
-
 
 private extern(C)
 {

--- a/src/dsfml/audio/package.d
+++ b/src/dsfml/audio/package.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /// Sounds, streaming (musics or custom sources), recording, spatialization.

--- a/src/dsfml/audio/sound.d
+++ b/src/dsfml/audio/sound.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -93,7 +96,6 @@ class Sound : SoundSource
         this();
 
         setBuffer(buffer);
-
     }
 
     /// Destructor.
@@ -121,6 +123,7 @@ class Sound : SoundSource
         {
             sfSound_setLoop(sfPtr, loop);
         }
+
         /// ditto
         bool isLooping()
         {
@@ -140,6 +143,7 @@ class Sound : SoundSource
         {
             sfSound_setPlayingOffset(sfPtr, offset.total!"usecs");
         }
+
         /// ditto
         Duration playingOffset()
         {
@@ -173,6 +177,7 @@ class Sound : SoundSource
         {
             sfSound_setPitch(sfPtr, newPitch);
         }
+
         /// ditto
         float pitch()
         {
@@ -192,6 +197,7 @@ class Sound : SoundSource
         {
             sfSound_setVolume(sfPtr, newVolume);
         }
+
         /// ditto
         float volume()
         {
@@ -212,6 +218,7 @@ class Sound : SoundSource
             sfSound_setPosition(sfPtr, newPosition.x, newPosition.y,
                                 newPosition.z);
         }
+
         /// ditto
         Vector3f position()
         {
@@ -237,6 +244,7 @@ class Sound : SoundSource
         {
             sfSound_setRelativeToListener(sfPtr, relative);
         }
+
         /// ditto
         bool relativeToListener()
         {
@@ -259,6 +267,7 @@ class Sound : SoundSource
         {
             sfSound_setMinDistance(sfPtr, distance);
         }
+
         /// ditto
         float minDistance()
         {
@@ -284,16 +293,13 @@ class Sound : SoundSource
         {
             sfSound_setAttenuation(sfPtr, newAttenuation);
         }
+
         /// ditto
         float attenuation()
         {
             return sfSound_getAttenuation(sfPtr);
         }
     }
-
-
-
-    //soundsource
 
     /*
      * Set the source buffer containing the audio data to play.

--- a/src/dsfml/audio/soundbuffer.d
+++ b/src/dsfml/audio/soundbuffer.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -93,9 +96,7 @@ import dsfml.audio.sound;
 import dsfml.system.inputstream;
 
 import std.stdio;
-
 import std.string;
-
 import std.algorithm;
 import std.array;
 
@@ -298,7 +299,6 @@ class SoundBuffer
         }
         else
         {
-
             err.write(dsfml.system.string.toString(sfErr_getOutput()));
             return false;
         }
@@ -336,7 +336,6 @@ unittest
     }
 }
 
-
 private extern(C++) interface sfmlInputStream
 {
     long read(void* data, long size);
@@ -347,7 +346,6 @@ private extern(C++) interface sfmlInputStream
 
     long getSize();
 }
-
 
 private class SoundBufferStream:sfmlInputStream
 {

--- a/src/dsfml/audio/soundbufferrecorder.d
+++ b/src/dsfml/audio/soundbufferrecorder.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -57,7 +60,6 @@ module dsfml.audio.soundbufferrecorder;
 
 import dsfml.audio.soundrecorder;
 import dsfml.audio.soundbuffer;
-
 
 /**
  * Specialized SoundRecorder which stores the captured audio data into a sound
@@ -155,14 +157,11 @@ unittest
         import dsfml.system.clock;
         import dsfml.system.sleep;
 
-
         writeln("Unit test for SoundBufferRecorder.");
 
         assert(SoundRecorder.isAvailable());
 
-
         auto recorder = new SoundBufferRecorder();
-
 
         auto clock = new Clock();
 
@@ -174,6 +173,7 @@ unittest
         {
             //wait for a second
         }
+
         writeln("2");
 
         clock.restart();
@@ -182,6 +182,7 @@ unittest
         {
             //wait for a second
         }
+
         writeln("1");
 
         clock.restart();
@@ -190,6 +191,7 @@ unittest
         {
             //wait for a second
         }
+
         writeln("Recording!");
 
         recorder.start();
@@ -202,13 +204,10 @@ unittest
 
         writeln("Done!");
 
-
         recorder.stop();
 
         auto buffer = recorder.getBuffer();
-
         auto recorderDuration = buffer.getDuration();
-
         auto recorderSound = new Sound(buffer);
 
         clock.restart();

--- a/src/dsfml/audio/soundrecorder.d
+++ b/src/dsfml/audio/soundrecorder.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -130,7 +133,6 @@ import core.thread;
 import core.time;
 import dsfml.system.string;
 import dsfml.system.err;
-
 
 /**
  * Abstract base class for capturing sound data.
@@ -266,7 +268,6 @@ class SoundRecorder
             {
                 availableDevices[i] = .toString(devices[i]);
             }
-
         }
 
         return availableDevices;
@@ -366,7 +367,6 @@ private:
 
 extern(C++) interface sfmlSoundRecorderCallBacks
 {
-
     bool onStart();
     bool onProcessSamples(const(short)* samples, size_t sampleCount);
     void onStop();
@@ -380,7 +380,6 @@ class SoundRecorderCallBacks: sfmlSoundRecorderCallBacks
 
     this(SoundRecorder recorder)
     {
-
         m_recorder = recorder;
     }
 

--- a/src/dsfml/audio/soundsource.d
+++ b/src/dsfml/audio/soundsource.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -65,6 +68,7 @@ interface SoundSource
          * as well. The default value for the pitch is 1.
          */
         void pitch(float newPitch);
+
         /// ditto
         float pitch();
     }
@@ -78,6 +82,7 @@ interface SoundSource
          * value for the volume is 100.
          */
         void volume(float newVolume);
+
         /// ditto
         float volume();
     }
@@ -91,6 +96,7 @@ interface SoundSource
          * default position of a sound is (0, 0, 0).
          */
         void position(Vector3f newPosition);
+
         /// ditto
         Vector3f position();
     }
@@ -108,6 +114,7 @@ interface SoundSource
          * is absolute).
          */
         void relativeToListener(bool relative);
+
         /// ditto
         bool relativeToListener();
     }
@@ -124,6 +131,7 @@ interface SoundSource
          * The default value of the minimum distance is 1.
          */
         void minDistance(float distance);
+
         /// ditto
         float minDistance();
     }
@@ -143,6 +151,7 @@ interface SoundSource
          * value of the attenuation is 1.
          */
         void attenuation(float newAttenuation);
+
         /// ditto
         float attenuation();
     }

--- a/src/dsfml/audio/soundstream.d
+++ b/src/dsfml/audio/soundstream.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -101,9 +104,7 @@ import core.time;
 import dsfml.audio.soundsource;
 
 import dsfml.system.vector3;
-
 import dsfml.system.err;
-
 
 /**
  * Abstract base class for streamed audio sources.
@@ -150,7 +151,6 @@ class SoundStream : SoundSource
         err.write(dsfml.system.string.toString(sfErr_getOutput()));
     }
 
-
     @property
     {
         /**
@@ -165,6 +165,7 @@ class SoundStream : SoundSource
         {
             sfSoundStream_setPitch(sfPtr, newPitch);
         }
+
         /// ditto
         float pitch()
         {
@@ -184,6 +185,7 @@ class SoundStream : SoundSource
         {
             sfSoundStream_setVolume(sfPtr, newVolume);
         }
+
         /// ditto
         float volume()
         {
@@ -203,6 +205,7 @@ class SoundStream : SoundSource
         {
             sfSoundStream_setPosition(sfPtr, newPosition.x, newPosition.y, newPosition.z);
         }
+
         /// ditto
         Vector3f position()
         {
@@ -226,6 +229,7 @@ class SoundStream : SoundSource
         {
             sfSoundStream_setLoop(sfPtr, loop);
         }
+
         /// ditto
         bool isLooping()
         {
@@ -246,6 +250,7 @@ class SoundStream : SoundSource
             sfSoundStream_setPlayingOffset(sfPtr, offset.total!"usecs");
 
         }
+
         /// ditto
         Duration playingOffset()
         {
@@ -269,6 +274,7 @@ class SoundStream : SoundSource
         {
             sfSoundStream_setRelativeToListener(sfPtr, relative);
         }
+
         /// ditto
         bool relativeToListener()
         {
@@ -291,6 +297,7 @@ class SoundStream : SoundSource
         {
             sfSoundStream_setMinDistance(sfPtr, distance);
         }
+
         /// ditto
         float minDistance()
         {
@@ -316,6 +323,7 @@ class SoundStream : SoundSource
         {
             sfSoundStream_setAttenuation(sfPtr, newAttenuation);
         }
+
         /// ditto
         float attenuation()
         {
@@ -425,8 +433,6 @@ class SoundStream : SoundSource
      *	timeOffset = New playing position, relative to the start of the stream
      */
     protected abstract void onSeek(Duration timeOffset);
-
-
 }
 
 private extern(C++)
@@ -465,24 +471,17 @@ class SoundStreamCallBacks: sfmlSoundStreamCallBacks
         (*chunk).sampleCount = samples.length;
 
         return ret;
-
     }
 
     extern(C++) void onSeek(long time)
     {
         m_stream.onSeek(usecs(time));
     }
-
-
-
 }
 
 private extern(C):
 
-
-
 struct sfSoundStream;
-
 
 sfSoundStream* sfSoundStream_construct(sfmlSoundStreamCallBacks callBacks);
 

--- a/src/dsfml/graphics/blendmode.d
+++ b/src/dsfml/graphics/blendmode.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**

--- a/src/dsfml/graphics/circleshape.d
+++ b/src/dsfml/graphics/circleshape.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -95,6 +98,7 @@ class CircleShape : Shape
             m_pointCount = newPointCount;
             return newPointCount;
         }
+
         /// ditto
         override uint pointCount()
         {
@@ -111,6 +115,7 @@ class CircleShape : Shape
             update();
             return newRadius;
         }
+
         /// ditto
         float radius()
         {

--- a/src/dsfml/graphics/color.d
+++ b/src/dsfml/graphics/color.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -62,9 +65,9 @@
  */
 module dsfml.graphics.color;
 
-import std.math, std.traits;
-
 import std.algorithm;
+import std.math;
+import std.traits;
 
 /**
  * Color is a utility struct for manipulating 32-bits RGBA colors.
@@ -338,7 +341,6 @@ unittest
         color/= 2;//(25, 25, 25, 25)
 
         color+= Color(40,20,10,5);//(65,45, 35, 30)
-
 
         color-= Color(5,10,20,40);//(60, 35, 15, 0)
 

--- a/src/dsfml/graphics/convexshape.d
+++ b/src/dsfml/graphics/convexshape.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -88,6 +91,7 @@ class ConvexShape : Shape
             update();
             return newPointCount;
         }
+
         /// ditto
         override uint pointCount()
         {
@@ -169,7 +173,6 @@ unittest
         convexShape.outlineColor = Color.Green;
 
         auto clock = new Clock();
-
 
         while(window.isOpen())
         {

--- a/src/dsfml/graphics/drawable.d
+++ b/src/dsfml/graphics/drawable.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**

--- a/src/dsfml/graphics/font.d
+++ b/src/dsfml/graphics/font.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -423,8 +426,6 @@ private class fontStream:fontInputStream
     }
 }
 
-
-
 package extern(C) struct sfFont;
 
 private extern(C):
@@ -434,30 +435,23 @@ sfFont* sfFont_construct();
 //Create a new font from a file
 bool sfFont_loadFromFile(sfFont* font, const(char)* filename, size_t length);
 
-
 //Create a new image font a file in memory
 bool sfFont_loadFromMemory(sfFont* font, const(void)* data, size_t sizeInBytes);
-
 
 //Create a new image font a custom stream
 bool sfFont_loadFromStream(sfFont* font, fontInputStream stream);
 
-
 // Copy an existing font
 sfFont* sfFont_copy(const sfFont* font);
-
 
 //Destroy an existing font
 void sfFont_destroy(sfFont* font);
 
-
 //Get a glyph in a font
 void sfFont_getGlyph(const(sfFont)* font, uint codePoint, int characterSize, bool bold, float* glyphAdvance, float* glyphBoundsLeft, float* glyphBoundsTop, float* glyphBoundsWidth, float* glyphBoundsHeight, int* glyphTextRectLeft, int* glyphTextRectTop, int* glyphTextRectWidth, int* glyphTextRectHeight);
 
-
 //Get the kerning value corresponding to a given pair of characters in a font
 float sfFont_getKerning(const(sfFont)* font, uint first, uint second, uint characterSize);
-
 
 //Get the line spacing value
 float sfFont_getLineSpacing(const(sfFont)* font, uint characterSize);
@@ -467,7 +461,6 @@ float sfFont_getUnderlinePosition (const(sfFont)* font, uint characterSize);
 
 //Get the thickness of the underline
 float sfFont_getUnderlineThickness (const(sfFont)* font, uint characterSize);
-
 
 //Get the texture pointer for a particular font
 sfTexture* sfFont_getTexturePtr(const(sfFont)* font);

--- a/src/dsfml/graphics/glsl.d
+++ b/src/dsfml/graphics/glsl.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -64,7 +67,6 @@ alias Vec3 = Vector3!(float);
 alias Ivec3 = Vector3!(int);
 /// 3D bool vector (bvec3 in GLSL)
 alias Bvec3 = Vector3!(bool);
-
 
 /**
  * 4D float vector (vec4 in GLSL)
@@ -217,7 +219,6 @@ struct Vector4(T)
             w = cast(T)source.a;
         }
     }
-
 }
 
 /**

--- a/src/dsfml/graphics/glyph.d
+++ b/src/dsfml/graphics/glyph.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**

--- a/src/dsfml/graphics/image.d
+++ b/src/dsfml/graphics/image.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -67,14 +70,12 @@
  */
 module dsfml.graphics.image;
 
-import dsfml.system.vector2;
-
 import dsfml.graphics.color;
-import dsfml.system.inputstream;
-
 import dsfml.graphics.rect;
 
 import dsfml.system.err;
+import dsfml.system.inputstream;
+import dsfml.system.vector2;
 
 /**
  * Class for loading, manipulating and saving images.
@@ -307,7 +308,7 @@ class Image
      */
     void copyImage(const(Image) source, uint destX, uint destY, IntRect sourceRect = IntRect(0,0,0,0), bool applyAlpha = false)
     {
-        sfImage_copyImage(sfPtr, source.sfPtr, destX, destY,sourceRect.left, sourceRect.top, sourceRect.width, sourceRect.height, applyAlpha);//:sfImage_copyImage(sfPtr, source.sfPtr, destX, destY, temp, sfFalse);
+        sfImage_copyImage(sfPtr, source.sfPtr, destX, destY,sourceRect.left, sourceRect.top, sourceRect.width, sourceRect.height, applyAlpha);
     }
 
     /**
@@ -383,7 +384,6 @@ unittest
 
         assert(image.getPixel(0,0) == Color.Green);
 
-
         image.flipHorizontally();
 
         assert(image.getPixel(99,0) == Color.Green);
@@ -398,7 +398,6 @@ unittest
     }
 }
 
-
 private extern(C++) interface imageInputStream
 {
     long read(void* data, long size);
@@ -409,7 +408,6 @@ private extern(C++) interface imageInputStream
 
     long getSize();
 }
-
 
 private class imageStream:imageInputStream
 {
@@ -441,7 +439,6 @@ private class imageStream:imageInputStream
     }
 }
 
-
 package extern(C) struct sfImage;
 
 private extern(C):
@@ -451,52 +448,52 @@ sfImage* sfImage_construct();
 
 void sfImage_create(sfImage* image, uint width, uint height);
 
-/// \brief Create an image and fill it with a unique color
+//Create an image and fill it with a unique color
 void sfImage_createFromColor(sfImage* image, uint width, uint height, ubyte r, ubyte b, ubyte g, ubyte a);
 
-/// \brief Create an image from an array of pixels
+//Create an image from an array of pixels
 void sfImage_createFromPixels(sfImage* image, uint width, uint height, const(ubyte)* pixels);
 
-/// \brief Create an image from a file on disk
+//Create an image from a file on disk
 bool sfImage_loadFromFile(sfImage* image, const(char)* filename, size_t length);
 
-/// \brief Create an image from a file in memory
+//Create an image from a file in memory
 bool sfImage_loadFromMemory(sfImage* image, const(void)* data, size_t size);
 
-/// \brief Create an image from a custom stream
+//Create an image from a custom stream
 bool sfImage_loadFromStream(sfImage* image, imageInputStream stream);
 
-/// \brief Copy an existing image
+//Copy an existing image
 sfImage* sfImage_copy(const(sfImage)* image);
 
-/// \brief Destroy an existing image
+//Destroy an existing image
 void sfImage_destroy(sfImage* image);
 
-/// \brief Save an image to a file on disk
+//Save an image to a file on disk
 bool sfImage_saveToFile(const sfImage* image, const char* filename, size_t length);
 
-/// \brief Return the size of an image
+//Return the size of an image
 void sfImage_getSize(const sfImage* image, uint* width, uint* height);
 
-/// \brief Create a transparency mask from a specified color-key
+//Create a transparency mask from a specified color-key
 void sfImage_createMaskFromColor(sfImage* image, ubyte r, ubyte b, ubyte g, ubyte a, ubyte alpha);
 
-/// \brief Copy pixels from an image onto another
+//Copy pixels from an image onto another
 void sfImage_copyImage(sfImage* image, const(sfImage)* source, uint destX, uint destY, int sourceRectLeft, int sourceRectTop, int sourceRectWidth, int sourceRectHeight, bool applyAlpha);
 
-/// \brief Change the color of a pixel in an image
+//Change the color of a pixel in an image
 void sfImage_setPixel(sfImage* image, uint x, uint y, ubyte r, ubyte b, ubyte g, ubyte a);
 
-/// \brief Get the color of a pixel in an image
+//Get the color of a pixel in an image
 void sfImage_getPixel(const sfImage* image, uint x, uint y, ubyte* r, ubyte* b, ubyte* g, ubyte* a);
 
-/// \brief Get a read-only pointer to the array of pixels of an image
+//Get a read-only pointer to the array of pixels of an image
 const(ubyte)* sfImage_getPixelsPtr(const sfImage* image);
 
-/// \brief Flip an image horizontally (left <-> right)
+//Flip an image horizontally (left <-> right)
 void sfImage_flipHorizontally(sfImage* image);
 
-/// \brief Flip an image vertically (top <-> bottom)
+//Flip an image vertically (top <-> bottom)
 void sfImage_flipVertically(sfImage* image);
 
 const(char)* sfErr_getOutput();

--- a/src/dsfml/graphics/package.d
+++ b/src/dsfml/graphics/package.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /// 2D graphics module: sprites, text, shapes, etc.

--- a/src/dsfml/graphics/primitivetype.d
+++ b/src/dsfml/graphics/primitivetype.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /// The module containing the list of usable primitives for drawing.

--- a/src/dsfml/graphics/rect.d
+++ b/src/dsfml/graphics/rect.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**

--- a/src/dsfml/graphics/rectangleshape.d
+++ b/src/dsfml/graphics/rectangleshape.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**

--- a/src/dsfml/graphics/renderstates.d
+++ b/src/dsfml/graphics/renderstates.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -107,7 +110,6 @@ struct RenderStates
 
         m_texture = null;
         m_shader = null;
-
     }
 
     /**
@@ -178,6 +180,7 @@ struct RenderStates
             m_shader = theShader;
             return theShader;
         }
+
         /// ditto
         const(Shader) shader()
         {
@@ -193,6 +196,7 @@ struct RenderStates
             m_texture = theTexture;
             return theTexture;
         }
+
         /// ditto
         const(Texture) texture()
         {

--- a/src/dsfml/graphics/rendertarget.d
+++ b/src/dsfml/graphics/rendertarget.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -74,6 +77,7 @@ interface RenderTarget
 		 * of `getDefaultView()` to this function.
 	 	 */
 		View view(View newView);
+
 		/// ditto
 		View view() const;
 	}

--- a/src/dsfml/graphics/rendertexture.d
+++ b/src/dsfml/graphics/rendertexture.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -85,24 +88,20 @@
  */
 module dsfml.graphics.rendertexture;
 
-import dsfml.graphics.rendertarget;
-import dsfml.graphics.view;
-import dsfml.graphics.rect;
-import dsfml.graphics.drawable;
-import dsfml.graphics.texture;
-import dsfml.graphics.renderstates;
-import dsfml.graphics.vertex;
-import dsfml.graphics.primitivetype;
-
-import dsfml.graphics.text;
-import dsfml.graphics.shader;
-
 import dsfml.graphics.color;
-
-import dsfml.system.vector2;
-
+import dsfml.graphics.drawable;
+import dsfml.graphics.primitivetype;
+import dsfml.graphics.rect;
+import dsfml.graphics.renderstates;
+import dsfml.graphics.rendertarget;
+import dsfml.graphics.shader;
+import dsfml.graphics.text;
+import dsfml.graphics.texture;
+import dsfml.graphics.vertex;
+import dsfml.graphics.view;
 
 import dsfml.system.err;
+import dsfml.system.vector2;
 
 /**
  * Target for off-screen 2D rendering into a texture.
@@ -164,6 +163,7 @@ class RenderTexture : RenderTarget
             sfRenderTexture_setSmooth(sfPtr, newSmooth);
             return newSmooth;
         }
+
         /// ditto
         bool smooth()
         {
@@ -191,6 +191,7 @@ class RenderTexture : RenderTarget
                                     newView.viewport.left, newView.viewport.top, newView.viewport.width, newView.viewport.height);
             return newView;
         }
+
         /// ditto
         override View view() const
         {
@@ -422,7 +423,6 @@ unittest
         auto texture = renderTexture.getTexture();
 
         writeln();
-
     }
 }
 

--- a/src/dsfml/graphics/renderwindow.d
+++ b/src/dsfml/graphics/renderwindow.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -119,7 +122,6 @@ module dsfml.graphics.renderwindow;
 import dsfml.graphics.color;
 import dsfml.graphics.image;
 import dsfml.graphics.rect;
-
 import dsfml.graphics.drawable;
 import dsfml.graphics.primitivetype;
 import dsfml.graphics.renderstates;
@@ -129,7 +131,6 @@ import dsfml.graphics.text;
 import dsfml.graphics.texture;
 import dsfml.graphics.view;
 import dsfml.graphics.vertex;
-
 
 import dsfml.window.contextsettings;
 import dsfml.window.windowhandle;
@@ -182,7 +183,6 @@ class RenderWindow : Window, RenderTarget
     this(T)(VideoMode mode, immutable(T)[] title, Style style = Style.DefaultStyle, ContextSettings settings = ContextSettings.init)
         if (is(T == dchar)||is(T == wchar)||is(T == char))
     {
-
         this();
         create(mode, title, style, settings);
     }
@@ -229,6 +229,7 @@ class RenderWindow : Window, RenderTarget
             sfRenderWindow_setPosition(sfPtr,newPosition.x, newPosition.y);
             return newPosition;
         }
+
         /// ditto
         override Vector2i position()
         {
@@ -248,6 +249,7 @@ class RenderWindow : Window, RenderTarget
             sfRenderWindow_setSize(sfPtr, newSize.x, newSize.y);
             return newSize;
         }
+
         /// ditto
         override Vector2u size()
         {
@@ -277,6 +279,7 @@ class RenderWindow : Window, RenderTarget
                                     newView.viewport.left, newView.viewport.top, newView.viewport.width, newView.viewport.height);
             return newView;
         }
+
         /// ditto
         override View view() const
         {
@@ -342,7 +345,7 @@ class RenderWindow : Window, RenderTarget
     }
 
     //this is a duplicate with the size property. Need to look into that
-    ///(Inherited from RenderTarget)
+    //(Inherited from RenderTarget)
     /**
      * Return the size of the rendering region of the target.
      *
@@ -879,7 +882,6 @@ class RenderWindow : Window, RenderTarget
     {
         return getWindowPointer(window);
     }
-
 }
 
 unittest
@@ -913,7 +915,7 @@ unittest
 
         window.setTitle("thing");//uses the first set title
 
-        window.setTitle("素晴らしい ！"d);//forces the dstring override and uses unicode
+        window.setTitle("素晴らしい ！"d);//forces the dstring override and uses utf-32
 
         window.setActive(true);
 
@@ -960,9 +962,7 @@ unittest
             window.draw(sprite);
 
             window.display();
-
         }
-
 
         writeln();
     }

--- a/src/dsfml/graphics/shader.d
+++ b/src/dsfml/graphics/shader.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**

--- a/src/dsfml/graphics/shape.d
+++ b/src/dsfml/graphics/shape.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -120,6 +123,7 @@ class Shape : Drawable, Transformable
             updateTexCoords();
             return rect;
         }
+
         /// ditto
         IntRect textureRect() const
         {
@@ -144,6 +148,7 @@ class Shape : Drawable, Transformable
             updateFillColors();
             return color;
         }
+
         /// ditto
         Color fillColor() const
         {
@@ -164,6 +169,7 @@ class Shape : Drawable, Transformable
             updateOutlineColors();
             return color;
         }
+
         /// ditto
         Color outlineColor() const
         {
@@ -186,6 +192,7 @@ class Shape : Drawable, Transformable
             update();
             return thickness;
         }
+
         /// ditto
         float outlineThickness() const
         {

--- a/src/dsfml/graphics/sprite.d
+++ b/src/dsfml/graphics/sprite.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -100,7 +103,6 @@ class Sprite : Drawable, Transformable
         Vertex[4] m_vertices;
         Rebindable!(const(Texture)) m_texture;
         IntRect m_textureRect;
-
     }
 
     /**
@@ -178,6 +180,7 @@ class Sprite : Drawable, Transformable
             m_vertices[3].color = newColor;
             return newColor;
         }
+
         /// ditto
         Color color()
         {
@@ -287,11 +290,13 @@ class Sprite : Drawable, Transformable
     Sprite dup() const
     {
         Sprite temp = new Sprite();
+
         // properties from Transformable
         temp.origin = origin;
         temp.position = position;
         temp.rotation = rotation;
         temp.scale = scale;
+
         // properties from Sprite:
         temp.setTexture(m_texture);
         temp.color = m_vertices[0].color;
@@ -339,7 +344,6 @@ unittest
         assert(texture.loadFromFile("res/TestImage.png"));
 
         auto sprite = new Sprite(texture);
-
 
         auto renderTexture = new RenderTexture();
 

--- a/src/dsfml/graphics/text.d
+++ b/src/dsfml/graphics/text.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -361,6 +364,7 @@ class Text : Drawable, Transformable
             {
                 //update the size
                 lastSizeUsed = m_characterSize;
+
                 //grab the new texture
                 lastTextureUsed = m_font.getTexture(m_characterSize);
             }
@@ -472,7 +476,6 @@ private:
         {
             dchar curChar = m_string[i];
 
-
             // Apply the kerning offset
             x += cast(float)(m_font.getKerning(prevChar, curChar, m_characterSize));
 
@@ -512,8 +515,6 @@ private:
                 // Next glyph, no need to create a quad for whitespace
                 continue;
             }
-
-
 
             // Extract the current glyph's description
             Glyph glyph = m_font.getGlyph(curChar, m_characterSize, bold);

--- a/src/dsfml/graphics/texture.d
+++ b/src/dsfml/graphics/texture.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -116,7 +119,6 @@
  */
 module dsfml.graphics.texture;
 
-
 import dsfml.graphics.rect;
 import dsfml.graphics.image;
 import dsfml.graphics.renderwindow;
@@ -212,7 +214,6 @@ class Texture
     bool loadFromMemory(const(void)[] data, IntRect area = IntRect())
     {
         import dsfml.system.string;
-
 
         bool ret = sfTexture_loadFromMemory(sfPtr, data.ptr, data.length,area.left, area.top,area.width, area.height);
         if(!ret)
@@ -435,7 +436,6 @@ class Texture
         return (sfTexture_isSmooth(sfPtr));
     }
 
-
     /**
      * Update the whole texture from an array of pixels.
      *
@@ -575,7 +575,6 @@ class Texture
             sfTexture_updateFromWindow(sfPtr, RenderWindow.windowPointer(T),
                                         x, y);
         }
-
     }
 
     /**
@@ -669,7 +668,6 @@ class Texture
     {
         sfTexture_updateFromRenderWindow(sfPtr, window.sfPtr, x, y);
     }
-
 }
 
 unittest
@@ -701,7 +699,6 @@ private extern(C++) interface textureInputStream
     long getSize();
 }
 
-
 private class textureStream:textureInputStream
 {
     private InputStream myStream;
@@ -731,8 +728,6 @@ private class textureStream:textureInputStream
         return myStream.getSize();
     }
 }
-
-
 
 package extern(C) struct sfTexture;
 

--- a/src/dsfml/graphics/transform.d
+++ b/src/dsfml/graphics/transform.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**

--- a/src/dsfml/graphics/transformable.d
+++ b/src/dsfml/graphics/transformable.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -152,6 +155,7 @@ interface Transformable
          * The default origin of a transformable object is (0, 0).
          */
         Vector2f origin(Vector2f newOrigin);
+
         /// ditto
         Vector2f origin() const;
     }
@@ -160,6 +164,7 @@ interface Transformable
     {
         /// The position of the object. The default is (0, 0).
         Vector2f position(Vector2f newPosition);
+
         /// ditto
         Vector2f position() const;
     }
@@ -168,6 +173,7 @@ interface Transformable
     {
         /// The orientation of the object, in degrees. The default is 0 degrees.
         float rotation(float newRotation);
+
         /// ditto
         float rotation() const;
     }
@@ -176,6 +182,7 @@ interface Transformable
     {
         /// The scale factors of the object. The default is (1, 1).
         Vector2f scale(Vector2f newScale);
+
         /// ditto
         Vector2f scale() const;
     }
@@ -205,7 +212,6 @@ interface Transformable
      * 		offset	= The offset
      */
     void move(Vector2f offset);
-
 }
 
 /**

--- a/src/dsfml/graphics/vertex.d
+++ b/src/dsfml/graphics/vertex.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**

--- a/src/dsfml/graphics/vertexarray.d
+++ b/src/dsfml/graphics/vertexarray.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -247,8 +250,6 @@ unittest
 
         assert(texture.loadFromFile("res/TestImage.png"));
 
-
-
         auto dimensions = FloatRect(0,0,texture.getSize().x,texture.getSize().y);
 
         auto vertexArray = new VertexArray(PrimitiveType.Quads, 0);
@@ -259,9 +260,7 @@ unittest
         vertexArray.append(Vertex(Vector2f(dimensions.width,dimensions.height), Color.Blue, Vector2f(dimensions.width,dimensions.height)));
         vertexArray.append(Vertex(Vector2f(dimensions.width,dimensions.top), Color.Blue, Vector2f(dimensions.width,dimensions.top)));
 
-
         auto renderStates = RenderStates(texture);
-
 
         auto renderTexture = new RenderTexture();
 

--- a/src/dsfml/graphics/view.d
+++ b/src/dsfml/graphics/view.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -46,7 +49,7 @@
  * auto window = RenderWindow();
  * auto view = View();
  *
- * // Initialize the view to a rectangle located at (100, 100) and with a size of 400x200
+ * // Initialize the view to a rectangle at (100, 100) and a size of 400x200
  * view.reset(FloatRect(100, 100, 400, 200));
  *
  * // Rotate it by 45 degrees
@@ -136,6 +139,7 @@ struct View
 
             return newCenter;
         }
+
         /// ditto
         Vector2f center() const
         {
@@ -160,6 +164,7 @@ struct View
 
             return newRotation;
         }
+
         /// ditto
         float rotation() const
         {
@@ -178,6 +183,7 @@ struct View
             m_invTransformUpdated = false;
             return newSize;
         }
+
         /// ditto
         Vector2f size() const
         {
@@ -203,6 +209,7 @@ struct View
 
             return newTarget;
         }
+
         /// ditto
         FloatRect viewport() const
         {
@@ -344,6 +351,7 @@ struct View
 
         return m_inverseTransform;
     }
+
     /// ditto
     Transform getInverseTransform() const
     {

--- a/src/dsfml/network/ftp.d
+++ b/src/dsfml/network/ftp.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -93,7 +96,6 @@ module dsfml.network.ftp;
 import core.time;
 
 import dsfml.network.ipaddress;
-
 
 /**
  * An FTP client.
@@ -468,7 +470,6 @@ class Ftp
             super(sfFtpListingResponse_getStatus(FtpListingResponce), sfFtpListingResponse_getMessage(FtpListingResponce));
 
             sfFtpListingResponse_destroy(FtpListingResponce);
-
         }
 
         /**
@@ -589,6 +590,7 @@ class Ftp
         }
     }
 }
+
 unittest
 {
     version(DSFML_Unittest_Network)
@@ -626,7 +628,6 @@ unittest
             assert(0);
         }
 
-
         auto directory = ftp.getWorkingDirectory();
         if (directory.isOk())
         {
@@ -662,7 +663,6 @@ unittest
 
 private extern(C):
 
-
 struct sfFtpDirectoryResponse;
 struct sfFtpListingResponse;
 struct sfFtpResponse;
@@ -681,114 +681,86 @@ Ftp.Response.Status sfFtpListingResponse_getStatus(const sfFtpListingResponse* f
 ///Get the full message contained in a FTP listing response
  const(char)* sfFtpListingResponse_getMessage(const(sfFtpListingResponse)* ftpListingResponse);
 
-
 ///Return the number of directory/file names contained in a FTP listing response
  size_t sfFtpListingResponse_getCount(const(sfFtpListingResponse)* ftpListingResponse);
 
-
 ///Return a directory/file name contained in a FTP listing response
  const(char)* sfFtpListingResponse_getName(const(sfFtpListingResponse)* ftpListingResponse, size_t index);
-
-
 
 //FTP Directory Responce Functions
 
 ///Destroy a FTP directory response
  void sfFtpDirectoryResponse_destroy(sfFtpDirectoryResponse* ftpDirectoryResponse);
 
-
 ///Get the status code of a FTP directory response
 Ftp.Response.Status sfFtpDirectoryResponse_getStatus(const(sfFtpDirectoryResponse)* ftpDirectoryResponse);
-
 
 ///Get the full message contained in a FTP directory response
  const(char)* sfFtpDirectoryResponse_getMessage(const(sfFtpDirectoryResponse)* ftpDirectoryResponse);
 
-
 ///Get the directory returned in a FTP directory response
  const(char)* sfFtpDirectoryResponse_getDirectory(const(sfFtpDirectoryResponse)* ftpDirectoryResponse);
-
-
 
 //FTP Responce functions
 
 ///Destroy a FTP response
  void sfFtpResponse_destroy(sfFtpResponse* ftpResponse);
 
-
 ///Get the status code of a FTP response
 Ftp.Response.Status sfFtpResponse_getStatus(const(sfFtpResponse)* ftpResponse);
 
-
 ///Get the full message contained in a FTP response
 const (char)* sfFtpResponse_getMessage(const sfFtpResponse* ftpResponse);
-
 
 ////FTP functions
 
 ///Create a new Ftp object
 sfFtp* sfFtp_create();
 
-
 ///Destroy a Ftp object
 void sfFtp_destroy(sfFtp* ftp);
-
 
 ///Connect to the specified FTP server
 sfFtpResponse* sfFtp_connect(sfFtp* ftp, IpAddress* serverIP, ushort port, long timeout);
 
-
 ///Log in using an anonymous account
 sfFtpResponse* sfFtp_loginAnonymous(sfFtp* ftp);
-
 
 ///Log in using a username and a password
 sfFtpResponse* sfFtp_login(sfFtp* ftp, const(char)* userName, size_t userNameLength, const(char)* password, size_t passwordLength);
 
-
 ///Close the connection with the server
 sfFtpResponse* sfFtp_disconnect(sfFtp* ftp);
-
 
 ///Send a null command to keep the connection alive
 sfFtpResponse* sfFtp_keepAlive(sfFtp* ftp);
 
-
 ///Get the current working directory
 sfFtpDirectoryResponse* sfFtp_getWorkingDirectory(sfFtp* ftp);
-
 
 ///Get the contents of the given directory
 sfFtpListingResponse* sfFtp_getDirectoryListing(sfFtp* ftp, const(char)* directory, size_t length);
 
-
 ///Change the current working directory
 sfFtpResponse* sfFtp_changeDirectory(sfFtp* ftp, const(char)* directory, size_t length);
-
 
 ///Go to the parent directory of the current one
 sfFtpResponse* sfFtp_parentDirectory(sfFtp* ftp);
 
-
 ///Create a new directory
 sfFtpResponse* sfFtp_createDirectory(sfFtp* ftp, const(char)* name, size_t length);
-
 
 ///Remove an existing directory
 sfFtpResponse* sfFtp_deleteDirectory(sfFtp* ftp, const(char)* name, size_t length);
 
-
 ///Rename an existing file
 sfFtpResponse* sfFtp_renameFile(sfFtp* ftp, const(char)* file, size_t fileLength, const(char)* newName, size_t newNameLength);
-
 
 ///Remove an existing file
 sfFtpResponse* sfFtp_deleteFile(sfFtp* ftp, const(char)* name, size_t length);
 
-
 ///Download a file from a FTP server
 sfFtpResponse* sfFtp_download(sfFtp* ftp, const(char)* distantFile, size_t distantFileLength, const(char)* destPath, size_t destPathLength, int mode);
-
 
 ///Upload a file to a FTP server
 sfFtpResponse* sfFtp_upload(sfFtp* ftp, const(char)* localFile, size_t localFileLength, const(char)* destPath, size_t destPathLength, int mode);

--- a/src/dsfml/network/http.d
+++ b/src/dsfml/network/http.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -224,7 +227,6 @@ class Http
             sfHttpRequest_setBody(sfPtrRequest, requestBody.ptr, requestBody.length);
         }
 
-
         /**
          * Set the value of a field.
          *
@@ -320,7 +322,6 @@ class Http
 
             InvalidResponse = 1000,
             ConnectionFailed = 1001
-
         }
 
         package sfHttpResponse* sfPtrResponse;
@@ -437,70 +438,54 @@ struct sfHttp;
 //Create a new HTTP request
 sfHttpRequest* sfHttpRequest_create();
 
-
 //Destroy a HTTP request
 void sfHttpRequest_destroy(sfHttpRequest* httpRequest);
-
 
 //Set the value of a header field of a HTTP request
 void sfHttpRequest_setField(sfHttpRequest* httpRequest, const(char)* field, size_t fieldLength, const(char)* value, size_t valueLength);
 
-
 //Set a HTTP request method
 void sfHttpRequest_setMethod(sfHttpRequest* httpRequest, int method);
-
 
 //Set a HTTP request URI
 void sfHttpRequest_setUri(sfHttpRequest* httpRequest, const(char)* uri, size_t length);
 
-
 //Set the HTTP version of a HTTP request
 void sfHttpRequest_setHttpVersion(sfHttpRequest* httpRequest,uint major, uint minor);
 
-
 //Set the body of a HTTP request
 void sfHttpRequest_setBody(sfHttpRequest* httpRequest, const(char)* ody, size_t length);
-
 
 //HTTP Response Functions
 
 //Destroy a HTTP response
 void sfHttpResponse_destroy(sfHttpResponse* httpResponse);
 
-
 //Get the value of a field of a HTTP response
 const(char)* sfHttpResponse_getField(const sfHttpResponse* httpResponse, const(char)* field, size_t length);
-
 
 //Get the status code of a HTTP reponse
 Http.Response.Status sfHttpResponse_getStatus(const sfHttpResponse* httpResponse);
 
-
 //Get the major HTTP version number of a HTTP response
 uint sfHttpResponse_getMajorVersion(const sfHttpResponse* httpResponse);
-
 
 //Get the minor HTTP version number of a HTTP response
 uint sfHttpResponse_getMinorVersion(const sfHttpResponse* httpResponse);
 
-
 //Get the body of a HTTP response
 const(char)* sfHttpResponse_getBody(const sfHttpResponse* httpResponse);
-
 
 //HTTP Functions
 
 //Create a new Http object
 sfHttp* sfHttp_create();
 
-
 //Destroy a Http object
 void sfHttp_destroy(sfHttp* http);
 
-
 //Set the target host of a HTTP object
 void sfHttp_setHost(sfHttp* http, const(char)* host, size_t length, ushort port);
-
 
 //Send a HTTP request and return the server's response.
 sfHttpResponse* sfHttp_sendRequest(sfHttp* http, const(sfHttpRequest)* request, long timeout);

--- a/src/dsfml/network/ipaddress.d
+++ b/src/dsfml/network/ipaddress.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -220,7 +223,6 @@ struct IpAddress
     static immutable(IpAddress) Broadcast = IpAddress(255,255,255,255);
 }
 
-
 //these have the same implementation, but use different names for readability
 private uint htonl(uint host) nothrow @nogc @safe
 {
@@ -247,7 +249,6 @@ private uint ntohl(uint network) nothrow @nogc @safe
         return network;
     }
 }
-
 
 unittest
 {

--- a/src/dsfml/network/package.d
+++ b/src/dsfml/network/package.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**

--- a/src/dsfml/network/packet.d
+++ b/src/dsfml/network/packet.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -321,7 +324,6 @@ package class SfPacket
         sfPacket_destroy(sfPtr);
     }
 
-
     //Get a slice of the data contained in the packet.
     //
     //Returns: Slice containing the data.
@@ -338,7 +340,6 @@ package class SfPacket
         sfPacket_append(sfPtr, data.ptr, void.sizeof * data.length);
     }
 }
-
 
 unittest
 {
@@ -426,38 +427,29 @@ struct sfPacket;
 ///Create a new packet
 sfPacket* sfPacket_create();
 
-
 ///Create a new packet by copying an existing one
 sfPacket* sfPacket_copy(const sfPacket* packet);
-
 
 ///Destroy a packet
 void sfPacket_destroy(sfPacket* packet);
 
-
 ///Append data to the end of a packet
 void sfPacket_append(sfPacket* packet, const void* data, size_t sizeInBytes);
-
 
 ///Clear a packet
 void sfPacket_clear(sfPacket* packet);
 
-
 ///Get a pointer to the data contained in a packet
 const(void)* sfPacket_getData(const sfPacket* packet);
-
 
 ///Get the size of the data contained in a packet
 size_t sfPacket_getDataSize(const sfPacket* packet);
 
-
 ///Tell if the reading position has reached the end of a packet
 bool sfPacket_endOfPacket(const sfPacket* packet);
 
-
 ///Test the validity of a packet, for reading
 bool sfPacket_canRead(const sfPacket* packet);
-
 
 ///Functions to extract data from a packet
 bool    sfPacket_readBool(sfPacket* packet);

--- a/src/dsfml/network/socket.d
+++ b/src/dsfml/network/socket.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -94,4 +97,3 @@ interface Socket
      */
     bool isBlocking() const;
 }
-

--- a/src/dsfml/network/socketselector.d
+++ b/src/dsfml/network/socketselector.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -290,7 +293,6 @@ unittest
         import std.stdio;
         import dsfml.network.ipaddress;
 
-
         writeln("Unittest for SocketSelector");
 
         auto selector = new SocketSelector();
@@ -305,7 +307,6 @@ unittest
         //The client tries to connect to the server
         auto clientSocket = new TcpSocket();
         clientSocket.connect(IpAddress.LocalHost, 55004);
-
 
         //wait for the selector to be informed of new things!
         selector.wait();
@@ -332,30 +333,24 @@ sfSocketSelector* sfSocketSelector_create();
 //Create a new socket selector by copying an existing one
 sfSocketSelector* sfSocketSelector_copy(const sfSocketSelector* selector);
 
-
 //Destroy a socket selector
 void sfSocketSelector_destroy(sfSocketSelector* selector);
-
 
 //Add a new socket to a socket selector
 void sfSocketSelector_addTcpListener(sfSocketSelector* selector, sfTcpListener* socket);
 void sfSocketSelector_addTcpSocket(sfSocketSelector* selector, sfTcpSocket* socket);
 void sfSocketSelector_addUdpSocket(sfSocketSelector* selector, sfUdpSocket* socket);
 
-
 //Remove a socket from a socket selector
 void sfSocketSelector_removeTcpListener(sfSocketSelector* selector, sfTcpListener* socket);
 void sfSocketSelector_removeTcpSocket(sfSocketSelector* selector, sfTcpSocket* socket);
 void sfSocketSelector_removeUdpSocket(sfSocketSelector* selector, sfUdpSocket* socket);
 
-
 //Remove all the sockets stored in a selector
 void sfSocketSelector_clear(sfSocketSelector* selector);
 
-
 //Wait until one or more sockets are ready to receive
 bool sfSocketSelector_wait(sfSocketSelector* selector, long timeout);
-
 
 //Test a socket to know if it is ready to receive data
 bool sfSocketSelector_isTcpListenerReady(const(sfSocketSelector)* selector, sfTcpListener* socket);

--- a/src/dsfml/network/tcplistener.d
+++ b/src/dsfml/network/tcplistener.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -63,7 +66,6 @@
  * $(TCPSOCKET_LINK), $(SOCKET_LINK)
  */
 module dsfml.network.tcplistener;
-
 
 import dsfml.network.ipaddress;
 import dsfml.network.socket;
@@ -172,7 +174,6 @@ class TcpListener:Socket
     {
         return (sfTcpListener_isBlocking(sfPtr));
     }
-
 }
 
 unittest
@@ -195,7 +196,6 @@ unittest
         //get our client socket to connect to the server
         clientSocket.connect(IpAddress.LocalHost, 55002);
 
-
         //socket on the server side connected to the client's socket
         auto serverSocket = new TcpSocket();
 
@@ -213,26 +213,20 @@ struct sfTcpListener;
 
 sfTcpListener* sfTcpListener_create();
 
-
 //Destroy a TCP listener
 void sfTcpListener_destroy(sfTcpListener* listener);
-
 
 //Set the blocking state of a TCP listener
 void sfTcpListener_setBlocking(sfTcpListener* listener, bool blocking);
 
-
 //Tell whether a TCP listener is in blocking or non-blocking mode
 bool sfTcpListener_isBlocking(const sfTcpListener* listener);
-
 
 //Get the port to which a TCP listener is bound locally
 ushort sfTcpListener_getLocalPort(const(sfTcpListener)* listener);
 
-
 //Start listening for connections
 Socket.Status sfTcpListener_listen(sfTcpListener* listener, ushort port, IpAddress* address);
-
 
 //Accept a new connection
 Socket.Status sfTcpListener_accept(sfTcpListener* listener, sfTcpSocket* connected);

--- a/src/dsfml/network/tcpsocket.d
+++ b/src/dsfml/network/tcpsocket.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -391,50 +394,38 @@ struct sfTcpSocket;
 //Create a new TCP socket
 sfTcpSocket* sfTcpSocket_create();
 
-
 //Destroy a TCP socket
 void sfTcpSocket_destroy(sfTcpSocket* socket);
-
 
 //Set the blocking state of a TCP listener
 void sfTcpSocket_setBlocking(sfTcpSocket* socket, bool blocking);
 
-
 //Tell whether a TCP socket is in blocking or non-blocking mode
 bool sfTcpSocket_isBlocking(const(sfTcpSocket)* socket);
-
 
 //Get the port to which a TCP socket is bound locally
 ushort sfTcpSocket_getLocalPort(const(sfTcpSocket)* socket);
 
-
 //Get the address of the connected peer of a TCP socket
 void sfTcpSocket_getRemoteAddress(const(sfTcpSocket)* socket, IpAddress* ipAddress);
-
 
 //Get the port of the connected peer to which a TCP socket is connected
 ushort sfTcpSocket_getRemotePort(const(sfTcpSocket)* socket);
 
-
 //Connect a TCP socket to a remote peer
 Socket.Status sfTcpSocket_connect(sfTcpSocket* socket, IpAddress* host, ushort port, long timeout);
-
 
 //Disconnect a TCP socket from its remote peer
 void sfTcpSocket_disconnect(sfTcpSocket* socket);
 
-
 //Send raw data to the remote peer of a TCP socket
 Socket.Status sfTcpSocket_send(sfTcpSocket* socket, const void* data, size_t size);
-
 
 //Receive raw data from the remote peer of a TCP socket
 Socket.Status sfTcpSocket_receive(sfTcpSocket* socket, void* data, size_t maxSize, size_t* sizeReceived);
 
-
 //Send a formatted packet of data to the remote peer of a TCP socket
 Socket.Status sfTcpSocket_sendPacket(sfTcpSocket* socket, sfPacket* packet);
-
 
 //Receive a formatted packet of data from the remote peer
 Socket.Status sfTcpSocket_receivePacket(sfTcpSocket* socket, sfPacket* packet);

--- a/src/dsfml/network/udpsocket.d
+++ b/src/dsfml/network/udpsocket.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -132,7 +135,6 @@ class UdpSocket:Socket
         mixin(destructorOutput);
         sfUdpSocket_destroy(sfPtr);
     }
-
 
     /**
      * Get the port to which the socket is bound locally.
@@ -309,7 +311,6 @@ class UdpSocket:Socket
     {
         sfUdpSocket_unbind(sfPtr);
     }
-
 }
 
 unittest
@@ -329,21 +330,17 @@ unittest
 
         serverSocket.bind(56002);
 
-
-        //auto sendingPacket = new Packet();
-
-        //sendingPacket.writeString("I sent you data!");
-        writeln("Sending data!");
         //send the data to the port our server is listening to
+        writeln("Sending data!");
         clientSocket.send("I sent you data!", IpAddress.LocalHost, 56002);
 
+        ////////////////////////////////////////////////////////////////////////
 
         IpAddress receivedFrom;
         ushort receivedPort;
         auto receivedPacket = new Packet();
 
         //get the information received as well as information about the sender
-        //serverSocket.receive(receivedPacket,receivedFrom, receivedPort);
 
         char[1024] temp2;
         size_t received;
@@ -353,7 +350,6 @@ unittest
 
         //What did we get?!
         writeln("The data received from ", receivedFrom, " at port ", receivedPort, " was: ", cast(string)temp2[0..received]);
-
 
         writeln();
     }

--- a/src/dsfml/system/clock.d
+++ b/src/dsfml/system/clock.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**

--- a/src/dsfml/system/config.d
+++ b/src/dsfml/system/config.d
@@ -1,7 +1,7 @@
 ﻿/*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /// A module containing configuration settings.

--- a/src/dsfml/system/err.d
+++ b/src/dsfml/system/err.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -90,7 +93,6 @@ unittest
 		err.writeln("This is the last line in the unit test to be written to err!");
 
 		writeln();
-
 	}
 
 }

--- a/src/dsfml/system/inputstream.d
+++ b/src/dsfml/system/inputstream.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -207,16 +210,12 @@ unittest
 			}
 		}
 
-
-
-
 		writeln("Unit test for InputStream");
 
 		auto streamTexture = new Texture();
 
 		writeln();
 		writeln("Using a basic file stream to load a non existant texture to confirm correct errors are found.");
-
 
 		auto failStream = new FileStream();
 		failStream.open("nonexistantTexture.png");//doesn't open the stream, but you should be checking if open returns true

--- a/src/dsfml/system/lock.d
+++ b/src/dsfml/system/lock.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -146,7 +149,6 @@ unittest
 			}
 			//unlock auto happens here
 		}
-
 
 		writeln("Unit test for Lock struct");
 		writeln();

--- a/src/dsfml/system/mutex.d
+++ b/src/dsfml/system/mutex.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -117,7 +120,6 @@ class Mutex
 		m_mutex.unlock();
 	}
 }
-
 
 unittest
 {

--- a/src/dsfml/system/package.d
+++ b/src/dsfml/system/package.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /// Base module of SFML, defining various utilities.

--- a/src/dsfml/system/sleep.d
+++ b/src/dsfml/system/sleep.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /// A module containing the sleep function.
@@ -41,7 +44,6 @@ void sleep(Duration duration)
 	import core.thread;
 	Thread.sleep(duration);
 }
-
 
 unittest
 {

--- a/src/dsfml/system/string.d
+++ b/src/dsfml/system/string.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -89,5 +92,4 @@ unittest
 
 		writeln("Unit test for string functions");
 	}
-
 }

--- a/src/dsfml/system/thread.d
+++ b/src/dsfml/system/thread.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -120,7 +123,6 @@ class Thread
 			m_thread.join(true);
 		}
 	}
-
 }
 
 unittest
@@ -131,7 +133,6 @@ unittest
 		import dsfml.system.sleep;
 		import core.time;
 
-
 		void secondThreadHello()
 		{
 			for(int i = 0; i < 10; ++i)
@@ -140,16 +141,12 @@ unittest
 			}
 		}
 
-
-
-
 		writeln("Unit test for Thread class");
 		writeln();
 
 		writeln("Running two functions at once.");
 
 		auto secondThread = new Thread(&secondThreadHello);
-
 
 		secondThread.launch();
 
@@ -173,5 +170,4 @@ unittest
 		//	writeln("Hello from the main thread!");
 		//}
 	}
-
 }

--- a/src/dsfml/system/vector2.d
+++ b/src/dsfml/system/vector2.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -72,6 +75,7 @@ struct Vector2(T)
 {
 	/// X coordinate of the vector.
 	T x;
+
 	/// Y coordinate of the vector.
 	T y;
 
@@ -196,8 +200,10 @@ struct Vector2(T)
 
 /// Definition of a Vector2 of integers.
 alias Vector2!(int) Vector2i;
+
 /// Definition of a Vector2 of floats.
 alias Vector2!(float) Vector2f;
+
 /// Definition of a Vector2 of unsigned integers.
 alias Vector2!(uint) Vector2u;
 

--- a/src/dsfml/system/vector3.d
+++ b/src/dsfml/system/vector3.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -66,8 +69,10 @@ struct Vector3(T)
 {
 	/// X coordinate of the vector.
 	T x;
+
 	/// Y coordinate of the vector.
 	T y;
+
 	/// Z coordinate of the vector.
 	T z;
 
@@ -120,7 +125,6 @@ struct Vector3(T)
 		{
 			return Vector3!(T)(cast(T)(x-otherVector.x),cast(T)(y-otherVector.y),cast(T)(z - otherVector.z));
 		}
-
 	}
 
 	/// Multiply/Divide a Vector3 with a numaric value.
@@ -204,6 +208,7 @@ struct Vector3(T)
 
 /// Definition of a Vector3 of integers.
 alias Vector3!(int) Vector3i;
+
 /// Definition of a Vector3 of floats.
 alias Vector3!(float) Vector3f;
 
@@ -244,5 +249,4 @@ unittest
 		writeln("Vector3 tests passed");
 		writeln();
 	}
-
 }

--- a/src/dsfml/window/context.d
+++ b/src/dsfml/window/context.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**

--- a/src/dsfml/window/contextsettings.d
+++ b/src/dsfml/window/contextsettings.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**

--- a/src/dsfml/window/event.d
+++ b/src/dsfml/window/event.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -102,8 +105,10 @@ struct Event
     {
         /// Index of the joystick (in range [0 .. Joystick::Count - 1])
         uint joystickId;
+
         /// Axis on which the joystick moved
         int axis;
+
         /// New position on the axis (in range [-100 .. 100])
         float position;
     }
@@ -115,12 +120,16 @@ struct Event
     {
         /// Code of the key that has been pressed.
         Keyboard.Key code;
+
         /// Is the Alt key pressed?
         bool alt;
+
         /// Is the Control key pressed?
         bool control;
+
         /// Is the Shift key pressed?
         bool shift;
+
         /// Is the System key pressed?
         bool system;
     }
@@ -220,6 +229,7 @@ struct Event
     {
         ///New width, in pixels
         uint width;
+
         ///New height, in pixels
         uint height;
     }
@@ -240,10 +250,13 @@ struct Event
     {
         ///Type of the sensor
         Sensor.Type type;
+
         /// Current value of the sensor on X axis
         float x;
+
         /// Current value of the sensor on Y axis
         float y;
+
         /// Current value of the sensor on Z axis
         float z;
     }
@@ -255,8 +268,10 @@ struct Event
     {
         ///Index of the finger in case of multi-touch events.
         uint finger;
+
         /// X position of the touch, relative to the left of the owner window.
         int x;
+
         /// Y position of the touch, relative to the top of the owner window.
         int y;
     }
@@ -322,26 +337,37 @@ struct Event
     {
         /// Size event parameters (Event::Resized)
         SizeEvent size;
+
         /// Key event parameters (Event::KeyPressed, Event::KeyReleased)
         KeyEvent key;
+
         /// Text event parameters (Event::TextEntered)
         TextEvent text;
+
         /// Mouse move event parameters (Event::MouseMoved)
         MouseMoveEvent mouseMove;
+
         /// Mouse button event parameters (Event::MouseButtonPressed, Event::MouseButtonReleased)
         MouseButtonEvent mouseButton;
+
         /// Mouse wheel event parameters (Event::MouseWheelMoved)
         MouseWheelEvent mouseWheel;
+
         /// Mouse wheel scroll event parameters
         MouseWheelScrollEvent mouseWheelScroll;
+
         /// Joystick move event parameters (Event::JoystickMoved)
         JoystickMoveEvent joystickMove;
+
         /// Joystick button event parameters (Event::JoystickButtonPressed, Event::JoystickButtonReleased)
         JoystickButtonEvent joystickButton;
+
         /// Joystick (dis)connect event parameters (Event::JoystickConnected, Event::JoystickDisconnected)
         JoystickConnectEvent joystickConnect;
+
         /// Touch event parameters
         TouchEvent touch;
+
         /// Sensor event Parameters
         SensorEvent sensor;
     }
@@ -609,7 +635,6 @@ unittest
             window.draw(joystickEventText);
 
             window.display();
-
         }
     }
 }

--- a/src/dsfml/window/joystick.d
+++ b/src/dsfml/window/joystick.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -84,8 +87,10 @@ final abstract class Joystick
     struct Identification
     {
         private static dstring[immutable(uint)[2]] nameCache;
+
         /// Index of the joystick.
         uint index;
+
         /// Name of the joystick.
         @property dstring name()
         {
@@ -117,6 +122,7 @@ final abstract class Joystick
 
         /// Manufacturer identifier.
         uint vendorId;
+
         /// Product identifier.
         uint productId;
     }
@@ -265,7 +271,6 @@ unittest
 {
     version(DSFML_Unittest_Window)
     {
-
         import std.stdio;
 
         Joystick.update();
@@ -306,11 +311,8 @@ unittest
                     if(Joystick.hasAxis(i,axis))
                     {
                         writeln("Axis ", axis, " has a position of ", Joystick.getAxisPosition(i,axis), "for joystick", i);
-
-
                     }
                 }
-
             }
         }
     }

--- a/src/dsfml/window/keyboard.d
+++ b/src/dsfml/window/keyboard.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**

--- a/src/dsfml/window/mouse.d
+++ b/src/dsfml/window/mouse.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -179,13 +182,11 @@ unittest
         Mouse.setPosition(Vector2i(100,400));
 
         writeln("New mouse position: ", Mouse.getPosition().toString());
-
     }
 }
 
 private extern(C)
 {
-
     //Check if a mouse button is pressed
     bool sfMouse_isButtonPressed(int button);
 

--- a/src/dsfml/window/package.d
+++ b/src/dsfml/window/package.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 

--- a/src/dsfml/window/sensor.d
+++ b/src/dsfml/window/sensor.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -147,7 +150,6 @@ final abstract class Sensor
 
 private extern(C)
 {
-
     //Check if a sensor is available
     bool sfSensor_isAvailable (int sensor);
 

--- a/src/dsfml/window/touch.d
+++ b/src/dsfml/window/touch.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -131,7 +134,6 @@ final abstract class Touch
 
 private extern(C)
 {
-
     //Check if a touch event is currently down
     bool sfTouch_isDown (uint finger);
 

--- a/src/dsfml/window/videomode.d
+++ b/src/dsfml/window/videomode.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -67,8 +70,10 @@ struct VideoMode
 {
 	///Video mode width, in pixels.
 	uint width;
+
 	///Video mode height, in pixels.
 	uint height;
+
 	///Video mode pixel depth, in bits per pixels.
 	uint bitsPerPixel;
 
@@ -137,7 +142,6 @@ struct VideoMode
 				videoModes[videoModeIndex] = temp;
 				++videoModeIndex;
 			}
-
 		}
 
 		return videoModes;

--- a/src/dsfml/window/window.d
+++ b/src/dsfml/window/window.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**
@@ -182,20 +185,21 @@ class Window
 		}
 	}
 
-	/**
-	 * Get's or set's the window's position.
-	 *
-	 * This function only works for top-level windows (i.e. it will be ignored
-	 * for windows created from the handle of a child window/control).
-	 */
 	@property
 	{
+		/**
+	 	 * Get's or set's the window's position.
+	 	 *
+	 	 * This function only works for top-level windows (i.e. it will be ignored
+	 	 * for windows created from the handle of a child window/control).
+	 	 */
 		Vector2i position(Vector2i newPosition)
 		{
 			sfWindow_setPosition(sfPtr,newPosition.x, newPosition.y);
 			return newPosition;
 		}
 
+		/// ditto
 		Vector2i position()
 		{
 			Vector2i temp;
@@ -204,14 +208,16 @@ class Window
 		}
 	}
 
-	///Get's or set's the window's size.
 	@property
 	{
+		/// Get's or set's the window's size.
 		Vector2u size(Vector2u newSize)
 		{
 			sfWindow_setSize(sfPtr, newSize.x, newSize.y);
 			return newSize;
 		}
+
+		// ditto
 		Vector2u size()
 		{
 			Vector2u temp;
@@ -343,7 +349,7 @@ class Window
 	 */
 	void setKeyRepeatEnabled(bool enabled)
 	{
-		enabled ? sfWindow_setKeyRepeatEnabled(sfPtr,true):sfWindow_setKeyRepeatEnabled(sfPtr,false);
+		sfWindow_setKeyRepeatEnabled(sfPtr, enabled);
 	}
 
 	/**
@@ -356,7 +362,7 @@ class Window
 	 */
 	void setMouseCursorVisible(bool visible)
 	{
-		visible ? sfWindow_setMouseCursorVisible(sfPtr,true): sfWindow_setMouseCursorVisible(sfPtr,false);
+		 sfWindow_setMouseCursorVisible(sfPtr, visible);
 	}
 
 	//Cannot use templates here as template member functions cannot be virtual.
@@ -399,7 +405,7 @@ class Window
 	 */
 	void setVisible(bool visible)
 	{
-		sfWindow_setVisible(sfPtr,visible);
+		sfWindow_setVisible(sfPtr, visible);
 	}
 
 	/**
@@ -417,7 +423,7 @@ class Window
 	 */
 	void setVerticalSyncEnabled(bool enabled)
 	{
-		enabled ? sfWindow_setVerticalSyncEnabled(sfPtr, true): sfWindow_setVerticalSyncEnabled(sfPtr, false);
+		sfWindow_setVerticalSyncEnabled(sfPtr, enabled);
 	}
 
 	/**
@@ -624,7 +630,6 @@ unittest
 
 		writeln("Unit test for Window class.");
 
-
 		//constructor
 		auto window = new Window(VideoMode(800,600),"Test Window");
 
@@ -673,6 +678,7 @@ unittest
 			{
 
 			}
+
 			//requires users input
 			if(window.waitEvent(event))
 			{

--- a/src/dsfml/window/windowhandle.d
+++ b/src/dsfml/window/windowhandle.d
@@ -1,7 +1,7 @@
 /*
  * DSFML - The Simple and Fast Multimedia Library for D
  *
- * Copyright (c) 2013 - 2017 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
+ * Copyright (c) 2013 - 2018 Jeremy DeHaan (dehaan.jeremiah@gmail.com)
  *
  * This software is provided 'as-is', without any express or implied warranty.
  * In no event will the authors be held liable for any damages arising from the
@@ -20,6 +20,9 @@
  * misrepresented as being the original software.
  *
  * 3. This notice may not be removed or altered from any source distribution
+ *
+ *
+ * DSFML is based on SFML (Copyright Laurent Gomila)
  */
 
 /**


### PR DESCRIPTION
This pull request updates the copyright dates in the license.

It also synchronizes the license text in the front and back ends, removes some white space + unnecessary stuff, and fixes the formatting in a couple of places.

This marks my triumphant return back to DSFML!
