### PR TITLE
Fix segfault in Music destructor

### DIFF
--- a/src/dsfml/audio/music.d
+++ b/src/dsfml/audio/music.d
@@ -110,7 +110,17 @@ class Music : SoundStream
     {
         import dsfml.system.config;
         mixin(destructorOutput);
-        stop();
+
+        /*
+         * Calling stop() causes a segmentation fault when m_mutex is
+         * destroyed before this destructor has run (which is what happens
+         * during a GC collection).
+         *
+         * It is probably OK to not call it here since it only resets the seek
+         * position on top of what the SoundStream destructor already does.
+         */
+
+        //stop();
     }
 
     /**


### PR DESCRIPTION
This fixes a segmentation fault that was happening in the Music class' destructor. Basically, when `stop()` is called in the destructor, the mutex used by the `SoundStream` has already been finalized and bad things happen when we try to lock the mutex.

I don't think we need to call `stop()` in the destructor because it only resets a couple of variables on top of what the `SoundStream` destructor already does.