### PR TITLE
Add an associative array of Textures by size to Font

### DIFF
--- a/include/DSFMLC/Graphics/Font.h
+++ b/include/DSFMLC/Graphics/Font.h
@@ -66,10 +66,7 @@ DSFML_GRAPHICS_API float sfFont_getUnderlinePosition (const sfFont * font, DUint
 //Get the thickness of the underline
 DSFML_GRAPHICS_API float sfFont_getUnderlineThickness (const sfFont * font, DUint charactersize);
 
-//Get the texture pointer for a particular font
-DSFML_GRAPHICS_API sfTexture* sfFont_getTexturePtr(const sfFont* font);
-
-//Update the internal texture associated with the font
-DSFML_GRAPHICS_API void sfFont_updateTexture(const sfFont* font, DUint characterSize);
+//Get the font texture for a given character size
+DSFML_GRAPHICS_API sfTexture* sfFont_getTexture(const sfFont* font, DUint characterSize);
 
 #endif // SFML_IMAGE_H

--- a/src/DSFMLC/Graphics/Font.cpp
+++ b/src/DSFMLC/Graphics/Font.cpp
@@ -32,15 +32,6 @@
 sfFont* sfFont_construct()
 {
     sfFont* font = new sfFont;
-    font->fontTexture = new sfTexture;
-
-    //Delete the internal texture and set OwnInstance to false
-    //This will allow us to set the sf::Texture vtable to the address
-    //of the one returned by the font without copying it or destroying it.
-    delete font->fontTexture->This;
-    font->fontTexture->This = 0;
-    font->fontTexture->OwnInstance = false;
-
     return font;
 }
 
@@ -67,7 +58,6 @@ sfFont* sfFont_copy(const sfFont* font)
 
 void sfFont_destroy(sfFont* font)
 {
-    //purposefully do not delete the texture as that is handled by the D Texture class
     delete font;
 }
 
@@ -106,15 +96,8 @@ float sfFont_getUnderlineThickness(const sfFont* font, DUint characterSize)
     return font->This.getUnderlineThickness(characterSize);
 }
 
-sfTexture* sfFont_getTexturePtr(const sfFont* font)
+sfTexture* sfFont_getTexture(const sfFont* font, DUint characterSize)
 {
-    return font->fontTexture;
-}
-
-void sfFont_updateTexture(const sfFont* font, DUint characterSize)
-{
-    //Get the address of the underlying sf::Texture to avoid copying it.
-    //This is safe because the underlying sf::Texture is only exposed in const form.
-    font->fontTexture->This = const_cast<sf::Texture*>(&(font->This.getTexture(characterSize)));
-
+    //This is safe because the D Texture that uses this is only exposed as const 
+    return new sfTexture(const_cast<sf::Texture*>(&(font->This.getTexture(characterSize))));
 }

--- a/src/DSFMLC/Graphics/FontStruct.h
+++ b/src/DSFMLC/Graphics/FontStruct.h
@@ -36,7 +36,6 @@
 struct sfFont
 {
     sf::Font This;
-    mutable sfTexture* fontTexture;
     sfmlStream Stream;
 };
 

--- a/src/dsfml/graphics/font.d
+++ b/src/dsfml/graphics/font.d
@@ -115,7 +115,8 @@ class Font
 
     package sfFont* sfPtr;
     private Info m_info;
-    private Texture fontTexture;
+    private Texture[int] textures;
+
     //keeps an instance of the C++ stream stored if used
     private fontStream m_stream;
 
@@ -127,13 +128,11 @@ class Font
     this()
     {
         sfPtr = sfFont_construct();
-        fontTexture = new Texture(sfFont_getTexturePtr(sfPtr));
     }
 
     package this(sfFont* newFont)
     {
         sfPtr = newFont;
-        fontTexture = new Texture(sfFont_getTexturePtr(sfPtr));
     }
 
     /// Destructor.
@@ -336,15 +335,17 @@ class Font
      *
      * Returns: Texture containing the glyphs of the requested size.
      */
-    const(Texture) getTexture (uint characterSize) const
+    const(Texture) getTexture (uint characterSize)
     {
-        //ToDo: cache texture somehow?
+        Texture ret = textures.get(characterSize, null);
 
-        import std.stdio;
+        if(ret is null)
+        {
+            ret = new Texture(sfFont_getTexture(sfPtr, characterSize));
+            textures[characterSize] = ret;
+        }
 
-        sfFont_updateTexture(sfPtr, characterSize);
-
-        return fontTexture;
+        return ret;
     }
 
     /**
@@ -462,12 +463,7 @@ float sfFont_getUnderlinePosition (const(sfFont)* font, uint characterSize);
 //Get the thickness of the underline
 float sfFont_getUnderlineThickness (const(sfFont)* font, uint characterSize);
 
-//Get the texture pointer for a particular font
-sfTexture* sfFont_getTexturePtr(const(sfFont)* font);
-
+//Get the font texture for a given character size
 sfTexture* sfFont_getTexture(const(sfFont)* font, uint characterSize);
-
-//Update the internal texture associated with the font
-void sfFont_updateTexture(const(sfFont)* font, uint characterSize);
 
 const(char)* sfErr_getOutput();

--- a/src/dsfml/graphics/text.d
+++ b/src/dsfml/graphics/text.d
@@ -113,16 +113,12 @@ class Text : Drawable, Transformable
     private
     {
         dstring m_string;
-        Rebindable!(const(Font)) m_font;
+        Font m_font;
         uint m_characterSize;
         Style m_style;
         Color m_color;
         VertexArray m_vertices;
         FloatRect m_bounds;
-
-        //used for caching the font texture
-        uint lastSizeUsed = 0;
-        Rebindable!(const(Texture)) lastTextureUsed;
     }
 
     /**
@@ -154,7 +150,7 @@ class Text : Drawable, Transformable
      *	font          = Font used to draw the string
      *	characterSize = Base size of characters, in pixels
      */
-    this(T)(immutable(T)[] text, const(Font) font, uint characterSize = 30)
+    this(T)(immutable(T)[] text, Font font, uint characterSize = 30)
         if (is(T == dchar)||is(T == wchar)||is(T == char))
     {
         import dsfml.system.string;
@@ -207,14 +203,7 @@ class Text : Drawable, Transformable
      */
     const(Font) getFont() const
     {
-        if(m_font is null)
-        {
-            return null;
-        }
-        else
-        {
-            return m_font;
-        }
+        return m_font;
     }
 
     /**
@@ -310,7 +299,7 @@ class Text : Drawable, Transformable
      * Params:
      * 		font	= New font
      */
-    void setFont(const(Font) font)
+    void setFont(Font font)
     {
         m_font = font;
         updateGeometry();
@@ -353,21 +342,9 @@ class Text : Drawable, Transformable
      */
     void draw(RenderTarget renderTarget, RenderStates renderStates)
     {
-        import std.stdio;
-
-        if ((m_font !is null) && (m_characterSize>0))
+        if (m_font !is null)
         {
             renderStates.transform *= getTransform();
-
-            //only call getTexture if the size has changed
-            if(m_characterSize != lastSizeUsed)
-            {
-                //update the size
-                lastSizeUsed = m_characterSize;
-
-                //grab the new texture
-                lastTextureUsed = m_font.getTexture(m_characterSize);
-            }
 
             updateGeometry();
 


### PR DESCRIPTION
This adds an associative array to store the textures a given font has.

The previous implementation used some weird hacks to avoid continuously making new `Texture` instances in D, but it had a few problems. This solution is much better.

Closes #261 