### PR TITLE
Update Text class to be current with SFML 2.4

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -108,6 +108,7 @@ Color
 Added the color * color and color*= color operators, which SFML calls
 modulation.
 
+
 GLSL
 ----
 Added glsl.d, which has all the types related to working with GLSL functions.
@@ -120,6 +121,11 @@ Added LineStrip, TriangleStrip, and TriangleFan members.
 LinesStrip, TrianglesStrip, and TrianglesFan were marked as deprecated (instead,
 use LineStrip, TriangleStrip, and TriangleFan respectively).
 
+Text
+----
+Updated Text class to be current as of SFML 2.4.
+
+Added properties to replace most getters/setters, which were then deprecated.
 
 RenderWindow
 ------------
@@ -140,6 +146,7 @@ Added opIndexAssign for new setUniform and setUniformArray where needed.
 Marked all setParameter functions as deprecated. Use their setUniform variants
 instead.
 
+
 Texture
 -------
 Marked updateFromImage, updateFromPixels, updateFromWindow, and updateFromWindow
@@ -148,6 +155,7 @@ which are now also work with const objects if they didn't already.
 
 Added update functions for pixels, an Image, and Window/RenderWindow without the
 need to define an x and y.
+
 
 Transform
 --------

--- a/include/DSFMLC/Graphics/Font.h
+++ b/include/DSFMLC/Graphics/Font.h
@@ -52,7 +52,7 @@ DSFML_GRAPHICS_API sfFont* sfFont_copy(const sfFont* font);
 DSFML_GRAPHICS_API void sfFont_destroy(sfFont* font);
 
 //Get a glyph in a font
-DSFML_GRAPHICS_API void sfFont_getGlyph(const sfFont* font, DUint codePoint, DInt characterSize, DBool bold, float* glyphAdvance, float* glyphBoundsLeft, float* glyphBoundsTop, float* glyphBoundsWidth, float* glyphBoundsHeight, DInt* glyphTextRectLeft, DInt* glyphTextRectTop, DInt* glyphTextRectWidth, DInt* glyphTextRectHeight);
+DSFML_GRAPHICS_API void sfFont_getGlyph(const sfFont* font, DUint codePoint, DInt characterSize, DBool bold, float outlineThickness, float* glyphAdvance, float* glyphBoundsLeft, float* glyphBoundsTop, float* glyphBoundsWidth, float* glyphBoundsHeight, DInt* glyphTextRectLeft, DInt* glyphTextRectTop, DInt* glyphTextRectWidth, DInt* glyphTextRectHeight);
 
 //Get the kerning value corresponding to a given pair of characters in a font
 DSFML_GRAPHICS_API float sfFont_getKerning(const sfFont* font, DUint first, DUint second, DUint characterSize);

--- a/src/DSFMLC/Graphics/Font.cpp
+++ b/src/DSFMLC/Graphics/Font.cpp
@@ -61,9 +61,9 @@ void sfFont_destroy(sfFont* font)
     delete font;
 }
 
-void sfFont_getGlyph(const sfFont* font, DUint codePoint, DInt characterSize, DBool bold, float* glyphAdvance, float* glyphBoundsLeft, float* glyphBoundsTop, float* glyphBoundsWidth, float* glyphBoundsHeight, DInt* glyphTextRectLeft, DInt* glyphTextRectTop, DInt* glyphTextRectWidth, DInt* glyphTextRectHeight)
+void sfFont_getGlyph(const sfFont* font, DUint codePoint, DInt characterSize, DBool bold, float outlineThickness, float* glyphAdvance, float* glyphBoundsLeft, float* glyphBoundsTop, float* glyphBoundsWidth, float* glyphBoundsHeight, DInt* glyphTextRectLeft, DInt* glyphTextRectTop, DInt* glyphTextRectWidth, DInt* glyphTextRectHeight)
 {
-    sf::Glyph SFMLGlyph = font->This.getGlyph(codePoint, characterSize, bold == DTrue);
+    sf::Glyph SFMLGlyph = font->This.getGlyph(codePoint, characterSize, bold == DTrue, outlineThickness);
 
     *glyphAdvance           = SFMLGlyph.advance;
     *glyphBoundsLeft        = SFMLGlyph.bounds.left;

--- a/src/dsfml/graphics/font.d
+++ b/src/dsfml/graphics/font.d
@@ -246,11 +246,11 @@ class Font
      *
      * Returns: The glyph corresponding to codePoint and characterSize.
      */
-    Glyph getGlyph(dchar codePoint, uint characterSize, bool bold) const
+    Glyph getGlyph(dchar codePoint, uint characterSize, bool bold, float outlineThickness = 0) const
     {
         Glyph temp;
 
-        sfFont_getGlyph(sfPtr, cast(uint)codePoint, characterSize,bold,&temp.advance,&temp.bounds.left,&temp.bounds.top,&temp.bounds.width,&temp.bounds.height,&temp.textureRect.left,&temp.textureRect.top,&temp.textureRect.width,&temp.textureRect.height);
+        sfFont_getGlyph(sfPtr, cast(uint)codePoint, characterSize, bold, outlineThickness, &temp.advance,&temp.bounds.left,&temp.bounds.top,&temp.bounds.width,&temp.bounds.height,&temp.textureRect.left,&temp.textureRect.top,&temp.textureRect.width,&temp.textureRect.height);
 
         return temp;
     }
@@ -449,7 +449,7 @@ sfFont* sfFont_copy(const sfFont* font);
 void sfFont_destroy(sfFont* font);
 
 //Get a glyph in a font
-void sfFont_getGlyph(const(sfFont)* font, uint codePoint, int characterSize, bool bold, float* glyphAdvance, float* glyphBoundsLeft, float* glyphBoundsTop, float* glyphBoundsWidth, float* glyphBoundsHeight, int* glyphTextRectLeft, int* glyphTextRectTop, int* glyphTextRectWidth, int* glyphTextRectHeight);
+void sfFont_getGlyph(const(sfFont)* font, uint codePoint, int characterSize, bool bold, float outlineThickness, float* glyphAdvance, float* glyphBoundsLeft, float* glyphBoundsTop, float* glyphBoundsWidth, float* glyphBoundsHeight, int* glyphTextRectLeft, int* glyphTextRectTop, int* glyphTextRectWidth, int* glyphTextRectHeight);
 
 //Get the kerning value corresponding to a given pair of characters in a font
 float sfFont_getKerning(const(sfFont)* font, uint first, uint second, uint characterSize);

--- a/src/dsfml/graphics/shape.d
+++ b/src/dsfml/graphics/shape.d
@@ -362,6 +362,7 @@ class Shape : Drawable, Transformable
     {
         Vector2f computeNormal(Vector2f p1, Vector2f p2)
         {
+            import std.math:sqrt;
             Vector2f normal = Vector2f(p1.y - p2.y, p2.x - p1.x);
             float length = sqrt(normal.x * normal.x + normal.y * normal.y);
             if (length != 0f)

--- a/src/dsfml/graphics/sprite.d
+++ b/src/dsfml/graphics/sprite.d
@@ -216,6 +216,7 @@ class Sprite : Drawable, Transformable
      */
     FloatRect getLocalBounds() const
     {
+        import std.math:abs;
         float width = (abs(m_textureRect.width));
         float height = (abs(m_textureRect.height));
         return FloatRect(0f, 0f, width, height);

--- a/src/dsfml/graphics/transform.d
+++ b/src/dsfml/graphics/transform.d
@@ -63,7 +63,6 @@ module dsfml.graphics.transform;
 
 import dsfml.system.vector2;
 import dsfml.graphics.rect;
-public import std.math;
 
 
 /**

--- a/src/dsfml/graphics/transformable.d
+++ b/src/dsfml/graphics/transformable.d
@@ -277,6 +277,7 @@ mixin template NormalTransformable()
 
     @property
     {
+        import std.math: fmod;
         float rotation(float newRotation)
         {
             m_rotation = cast(float)fmod(newRotation, 360);
@@ -324,6 +325,7 @@ mixin template NormalTransformable()
 
     const(Transform) getTransform()
     {
+        import std.math: cos, sin;
         if (m_transformNeedUpdate)
         {
             float angle = -m_rotation * 3.141592654f / 180f;

--- a/src/dsfml/graphics/vertexarray.d
+++ b/src/dsfml/graphics/vertexarray.d
@@ -92,7 +92,7 @@ class VertexArray : Drawable
      *  type        = Type of primitives
      *  vertexCount = Initial number of vertices in the array
      */
-    this(PrimitiveType type, uint vertexCount)
+    this(PrimitiveType type, uint vertexCount = 0)
     {
         primitiveType = type;
         Vertices = new Vertex[vertexCount];


### PR DESCRIPTION
This also deprecates many of the getters/setters in the Text class and
adds properties to replace them.

It also removes a public import from the Transform class, updates the
necessary files accordingly, and makes a few other small changes.

Fixes #202, fixes #253, and fixes #282.